### PR TITLE
Add setup.py to allow installs as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from setuptools import setup, find_packages  # noqa: H301
+
+with open("README.md") as f:
+    long_description = f.read()
+
+NAME = "refurbished"
+REQUIRES = ["lxml >= 4.5.0", "requests >= 2.23.0", "price-parser == 0.3.3"]
+
+setup(
+    name=NAME,
+    version="0.2.0",
+    description="library to search refurbished products on the Apple Store",
+    author_email="maurizio.branca@gmail.com",
+    url="https://github.com/zmoog/refurbished",
+    keywords=[],
+    install_requires=REQUIRES,
+    packages=find_packages(exclude=["test", "tests"]),
+    classifiers=[  # https://pypi.org/classifiers/
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+    ],
+    include_package_data=True,
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+)


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
I want install this package as a dependency of another one. 

### Change description
<!-- What does your code do? -->
Add missing `setup.py` so I can install it as a dependency using `pipenv`.

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `master`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.