### PR TITLE
Add product URL support

### DIFF
--- a/refurbished/parser.py
+++ b/refurbished/parser.py
@@ -10,7 +10,7 @@ from lxml import html
 from price_parser import Price
 
 
-Product = namedtuple('Product', 'name price previous_price savings_price')
+Product = namedtuple('Product', 'name url price previous_price savings_price')
 
 
 def parse_products(page: str):
@@ -25,10 +25,13 @@ def parse_products(page: str):
 
     return [Product(
         _parse_name(product),
+        _parse_url(product),
         _parse_current_price(product),
         _parse_previous_price(product),
-        _parse_savings_price(product))
-            for product in products]
+        _parse_savings_price(product),
+        )
+        for product in products
+    ]
 
 
 def _parse_name(product: html.HtmlElement) -> str:
@@ -56,6 +59,12 @@ def _parse_savings_price(product: html.HtmlElement) -> decimal.Decimal:
     return _extract_price(product.xpath(
         'span[@class="as-producttile-savingsprice"]/text()'
     ))
+
+
+def _parse_url(product: html.HtmlElement) -> str:
+    """Parse the fragment with product URL."""
+    href = product.xpath('h3/a/@href')[0]
+    return f'https://www.apple.com{href}'
 
 
 def _extract_price(price_as_text: List[str]) -> decimal.Decimal:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -45,6 +45,7 @@ class TestParser:
 
         product = products[0]
         assert product.name == 'iPad Wi-Fi 128GB ricondizionato - Argento (sesta generazione)'
+        assert product.url == 'https://www.apple.com/it/shop/product/FR7K2TY/A/Refurbished-iPad-Wi-Fi-128GB-Silver-6th-Generation?fnode=fdc6d8cf9a3a5596bf835118bf66d1c5629f169110e3c66008a511ee595b8dd45b4d55beb5e42e007c3cc2538e1432961e205bee33610351fa200165b97bfb12c52b24b5670f39ef2da2bb4482e95ada'
         assert product.price == decimal.Decimal('389.00')
         assert product.previous_price == decimal.Decimal('449.00')
         assert product.savings_price == decimal.Decimal('60.00')


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
When I list a refurbished product list I want to quickly open the a product page if I see something interesting.

### Change description
<!-- What does your code do? -->
 * Add a new `url` attribute to the Product model, and fill it with the URL to the web page on the Apple Store.

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->
I'm adding this to implement https://github.com/zmoog/concierge/issues/74

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `master`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.