### PR TITLE
Update product parser for the US store

### DIFF
--- a/refurbished/parser.py
+++ b/refurbished/parser.py
@@ -26,9 +26,16 @@ def parse_products(product_family: str, page: str) -> List[Product]:
     )
     store_domain = f"{current_parsed_url.scheme}://{current_parsed_url.netloc}"
 
+    # CSS classes for the products list.
+    css_classes = [
+       "refurbished-category-grid-no-js",  # used by most stores
+       "rf-refurb-category-grid-no-js"  # used by the "us" store
+    ]
+
     product_section = page.find(
-        "div", class_="refurbished-category-grid-no-js"
+        "div", class_=css_classes
     )
+
     if product_section is None:
         # For some products (for example, ipad on the 'fr' store) we get a
         # page with generic product information, but differenct structure

--- a/refurbished/parser.py
+++ b/refurbished/parser.py
@@ -28,13 +28,11 @@ def parse_products(product_family: str, page: str) -> List[Product]:
 
     # CSS classes for the products list.
     css_classes = [
-       "refurbished-category-grid-no-js",  # used by most stores
-       "rf-refurb-category-grid-no-js"  # used by the "us" store
+        "refurbished-category-grid-no-js",  # used by most stores
+        "rf-refurb-category-grid-no-js",  # used by the "us" store
     ]
 
-    product_section = page.find(
-        "div", class_=css_classes
-    )
+    product_section = page.find("div", class_=css_classes)
 
     if product_section is None:
         # For some products (for example, ipad on the 'fr' store) we get a

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -102,3 +102,11 @@ class TestParser:
         # product instead of an error.
         products = parse_products("ipad", html)
         assert len(products) == 0
+
+    def test_product_mac_us(self):
+        resource = pkgutil.get_data("tests", "us_mac.html")
+
+        html = io.BytesIO(resource).read().decode()
+
+        products = parse_products("mac", html)
+        assert len(products) > 0

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -109,4 +109,4 @@ class TestParser:
         html = io.BytesIO(resource).read().decode()
 
         products = parse_products("mac", html)
-        assert len(products) > 0
+        assert len(products) == 138

--- a/tests/us_mac.html
+++ b/tests/us_mac.html
@@ -1,0 +1,3396 @@
+<!DOCTYPE html>
+<html class="en-us amr nojs en seg-consumer us" lang="en-US">
+
+<head>
+    <meta name="viewport" content="width=1024" />
+    <title>Refurbished Mac Deals - Apple</title>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta name="format-detection" content="telephone=no" />
+    <meta property="og:locale" content="en_US" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta property="og:image"
+        content="https://as-images.apple.com/is/og-default?wid=1200&amp;hei=630&amp;fmt=jpeg&amp;qlt=95&amp;.v=1525370171638" />
+    <meta property="og:description"
+        content="Save up to 15% on a refurbished Mac. Tested and certified by Apple including a 1-year warranty. Free delivery and returns." />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Refurbished Mac Deals - Apple" />
+    <meta name="twitter:site" content="@apple" />
+    <meta property="og:url" content="https://www.apple.com/shop/refurbished/mac" />
+    <meta property="og:site_name" content="Apple" />
+    <meta name="description"
+        content="Save up to 15% on a refurbished Mac. Tested and certified by Apple including a 1-year warranty. Free delivery and returns." />
+
+
+
+    <link rel="canonical" href="https://www.apple.com/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="de-at" href="https://www.apple.com/at/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="ja-jp" href="https://www.apple.com/jp/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="en-ca" href="https://www.apple.com/ca/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="de-de" href="https://www.apple.com/de/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="es-es" href="https://www.apple.com/es/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="fr-ca" href="https://www.apple.com/xf/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="ko-kr" href="https://www.apple.com/kr/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="en-ie" href="https://www.apple.com/ie/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="en-us" href="https://www.apple.com/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="en-nz" href="https://www.apple.com/nz/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="fr-be" href="https://www.apple.com/be-fr/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="en-sg" href="https://www.apple.com/sg/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="nl-be" href="https://www.apple.com/be-nl/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="en-gb" href="https://www.apple.com/uk/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="en-au" href="https://www.apple.com/au/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="it-it" href="https://www.apple.com/it/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="zh-hant-tw" href="https://www.apple.com/tw/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="fr-fr" href="https://www.apple.com/fr/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="zh-hans-cn" href="https://www.apple.com.cn/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="en-hk" href="https://www.apple.com/hk/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="nl-nl" href="https://www.apple.com/nl/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="de-ch" href="https://www.apple.com/ch-de/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="zh-hant-hk" href="https://www.apple.com/hk-zh/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="fr-ch" href="https://www.apple.com/ch-fr/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="pt-br" href="https://www.apple.com/br/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="es-mx" href="https://www.apple.com/mx/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="hu-hu" href="https://www.apple.com/hu/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="cs-cz" href="https://www.apple.com/cz/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="fi-fi" href="https://www.apple.com/fi/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="tr-tr" href="https://www.apple.com/tr/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="pl-pl" href="https://www.apple.com/pl/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="sv-se" href="https://www.apple.com/se/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="en-ae" href="https://www.apple.com/ae/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="ru-ru" href="https://www.apple.com/ru/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="en-in" href="https://www.apple.com/in/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="no-no" href="https://www.apple.com/no/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="da-dk" href="https://www.apple.com/dk/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="fr-lu" href="https://www.apple.com/lu/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="pt-pt" href="https://www.apple.com/pt/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="en-ph" href="https://www.apple.com/ph/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="th-th" href="https://www.apple.com/th/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="en-th" href="https://www.apple.com/th-en/shop/refurbished/mac" />
+    <link rel="alternate" hreflang="en-my" href="https://www.apple.com/my/shop/refurbished/mac" />
+    <script> document.cookie = "as_sfa=Mnx1c3x1c3x8ZW5fVVN8Y29uc3VtZXJ8aW50ZXJuZXR8MHwwfDE; path=/; domain=apple.com; expires=Sun, 15-Jan-2023 21:40:42 GMT; Secure;"; </script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/G0UR3LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0UR3LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":4589.00,"sku":"G0UR3LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 32GB of 2666MHz DDR4 ECC memory 2TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 56 graphics processor with 8GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 7‑Core GPU - Space Gray","url":"https://www.apple.com/shop/product/FGN63LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8‑core-cpu-and-7‑core-gpu-space-gray","mainEntityOfPage":"https://www.apple.com/shop/product/FGN63LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8‑core-cpu-and-7‑core-gpu-space-gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":849.00,"sku":"FGN63LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-macbook-air-space-gray-m1-202010?wid=539&hei=312&fmt=jpeg&qlt=95&.v=1634145627000","description":"Originally released November 2020|13.3-inch (diagonal) LED-backlit display with IPS technology; 2560-by-1600 native resolution at 227 pixels per inch|8GB unified memory|256GB SSD1|Touch ID sensor|720p FaceTime HD Camera"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Space Gray","url":"https://www.apple.com/shop/product/G1252LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu-space-gray","mainEntityOfPage":"https://www.apple.com/shop/product/G1252LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu-space-gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1229.00,"sku":"G1252LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-macbook-air-space-gray-m1-202010?wid=539&hei=312&fmt=jpeg&qlt=95&.v=1634145627000","description":"Originally released November 2020|13.3-inch (diagonal) LED-backlit display with IPS technology; 2560-by-1600 native resolution at 227 pixels per inch|16GB unified memory|512GB SSD1|Touch ID sensor|720p FaceTime HD Camera"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac Pro 3.3GHz 12-core Intel Xeon W, Radeon Pro 580X","url":"https://www.apple.com/shop/product/G10LFLL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X","mainEntityOfPage":"https://www.apple.com/shop/product/G10LFLL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":7389.00,"sku":"G10LFLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-rack-2019?wid=2000&hei=1272&fmt=jpeg&qlt=95&.v=1605114669000","description":"Originally released December 2019 3.5GHz 8‑core Intel Xeon W processor, Turbo Boost up to 4.0GHz 48GB (6x8GB) of DDR4 ECC memory Radeon Pro 580X with 8GB of GDDR5 memory 256GB SSD storage Stainless steel frame with feet"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac Pro 2.5GHz 28-core Intel Xeon W, Two Radeon Pro Vega II Duo, Apple Afterburner","url":"https://www.apple.com/shop/product/G10TTLL/A/Refurbished-Mac-Pro-25GHz-28-core-Intel-Xeon-W-Two-Radeon-Pro-Vega-II-Duo-Apple-Afterburner","mainEntityOfPage":"https://www.apple.com/shop/product/G10TTLL/A/Refurbished-Mac-Pro-25GHz-28-core-Intel-Xeon-W-Two-Radeon-Pro-Vega-II-Duo-Apple-Afterburner","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":43599.00,"sku":"G10TTLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-rack-2019?wid=2000&hei=1272&fmt=jpeg&qlt=95&.v=1605114669000","description":"Originally released December 20193.2GHz 16‑core Intel Xeon W processor, Turbo Boost up to 4.4GHz48GB (6x8GB) of DDR4 ECC memoryTwo Radeon Pro Vega II Duo with 2x32GB of HBM2 memory each1TB SSD1 storageRack mounting rails (ships in separate box)Apple Afterburner"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray","url":"https://www.apple.com/shop/product/GMW2DLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","mainEntityOfPage":"https://www.apple.com/shop/product/GMW2DLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":2209.00,"sku":"GMW2DLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1553797551145","description":"In addition to being a great desktop computer, Mac mini powers everything from home automation to giant render farms. And now with eighth-generation Intel quad-core and 6-core processors and Intel UHD Graphics 630, Mac mini has even more compute power for industrial-grade tasks. So whether you’re running a live concert sound engine or testing your latest iOS app, Mac mini is the shortest distance between a great idea and a great result."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac 3.6GHz 10-core Intel Core i9 with Retina 5K display","url":"https://www.apple.com/shop/product/G11P5LL/A/refurbished-27-inch-imac-36ghz-10-core-intel-core-i9-with-retina-5k-display","mainEntityOfPage":"https://www.apple.com/shop/product/G11P5LL/A/refurbished-27-inch-imac-36ghz-10-core-intel-core-i9-with-retina-5k-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":3819.00,"sku":"G11P5LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-imac-27-2020?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1654865822599","description":"Originally released August 2020 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors True Tone technology 16GB of 2666MHz DDR4 memory 8TB SSD1 1080p FaceTime HD camera Radeon Pro 5700 with 8GB of GDDR6 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/GMURJLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/GMURJLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":5269.00,"sku":"GMURJLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017\n27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors\n32GB of 2666MHz DDR4 ECC memory\n2TB SSD storage\n1080p FaceTime HD camera\nRadeon Pro Vega 56 graphics processor with 8GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 2.3GHz 18-core Intel Xeon W with Retina 5K display and Radeon Pro Vega 64X","url":"https://www.apple.com/shop/product/GPUR2LL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display-and-Radeon-Pro-Vega-64X","mainEntityOfPage":"https://www.apple.com/shop/product/GPUR2LL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display-and-Radeon-Pro-Vega-64X","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":8239.00,"sku":"GPUR2LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 128GB of 2666MHz DDR4 ECC memory 2TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 64X graphics processor with 16GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display","url":"https://www.apple.com/shop/product/G0VYXLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0VYXLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1609.00,"sku":"G0VYXLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087778","description":"Originally released March 2019 21.5-inch (diagonal) Retina 4K display; 4096-by-2304 resolution with support for one billion colors 16GB of 2666MHz DDR4 memory 1TB Fusion Drive1 FaceTime HD camera Radeon Pro 560X"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display","url":"https://www.apple.com/shop/product/G0VYBLL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0VYBLL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1609.00,"sku":"G0VYBLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087778","description":"Originally released March 2019 21.5-inch (diagonal) Retina 4K display; 4096-by-2304 resolution with support for one billion colors 16GB of 2666MHz DDR4 memory 512GB SSD storage1 FaceTime HD camera Radeon Pro 560X"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display and Radeon Pro Vega 20","url":"https://www.apple.com/shop/product/GMVY4LL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display-and-Radeon-Pro-Vega-20","mainEntityOfPage":"https://www.apple.com/shop/product/GMVY4LL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display-and-Radeon-Pro-Vega-20","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":2249.00,"sku":"GMVY4LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087778","description":"Originally released March 2019 21.5-inch (diagonal) Retina 4K display; 4096-by-2304 resolution with support for one billion colors 16GB of 2666MHz DDR4 memory 1TB SSD storage1 FaceTime HD camera Radeon Pro Vega 20"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini 3.0GHz 6-core Intel Core i5 - Space Gray","url":"https://www.apple.com/shop/product/FXNG2LL/A/Refurbished-Mac-mini-30GHz-6-core-Intel-Core-i5-Space-Gray","mainEntityOfPage":"https://www.apple.com/shop/product/FXNG2LL/A/Refurbished-Mac-mini-30GHz-6-core-Intel-Core-i5-Space-Gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":929.00,"sku":"FXNG2LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1553797551145","description":"Originally released March 20208GB of 2666MHz DDR4 SO-DIMM memory512GB PCIe-based SSD1Four Thunderbolt 3 ports (up to 40 Gbps)Intel UHD Graphics 630Gigabit Ethernet port"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini 3.2GHz 6-core Intel Core i7, 10GB Ethernet - Space Gray","url":"https://www.apple.com/shop/product/G11LCLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","mainEntityOfPage":"https://www.apple.com/shop/product/G11LCLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":2549.00,"sku":"G11LCLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1553797551145","description":"Originally released March 202064GB of 2666MHz DDR4 SO-DIMM memory2TB PCIe-based SSD1Four Thunderbolt 3 ports (up to 40 Gbps)Intel UHD Graphics 63010 Gigabit Ethernet port"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display and Radeon Pro Vega 64X","url":"https://www.apple.com/shop/product/GNURELL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display-and-Radeon-Pro-Vega-64X","mainEntityOfPage":"https://www.apple.com/shop/product/GNURELL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display-and-Radeon-Pro-Vega-64X","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":5179.00,"sku":"GNURELL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 64GB of 2666MHz DDR4 ECC memory 1TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 64X graphics processor with 16GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/G0UR4LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0UR4LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":5059.00,"sku":"G0UR4LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 32GB of 2666MHz DDR4 ECC memory 2TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 64 graphics processor with 16GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Space Gray","url":"https://www.apple.com/shop/product/G1253LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu-space-gray","mainEntityOfPage":"https://www.apple.com/shop/product/G1253LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu-space-gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1399.00,"sku":"G1253LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-macbook-air-space-gray-m1-202010?wid=539&hei=312&fmt=jpeg&qlt=95&.v=1634145627000","description":"Originally released November 2020|13.3-inch (diagonal) LED-backlit display with IPS technology; 2560-by-1600 native resolution at 227 pixels per inch|16GB unified memory|1TB SSD1|Touch ID sensor|720p FaceTime HD Camera"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 13.3-inch MacBook Pro Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Space Gray","url":"https://www.apple.com/shop/product/FYD82LL/A/refurbished-133-inch-macbook-pro-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu-space-gray","mainEntityOfPage":"https://www.apple.com/shop/product/FYD82LL/A/refurbished-133-inch-macbook-pro-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu-space-gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1059.00,"sku":"FYD82LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp13-space-m1-2020?wid=1200&hei=1200&fmt=jpeg&qlt=95&.v=1628621779000","description":"The Apple M1 chip gives the 13‑inch MacBook Pro speed and power beyond belief. With up to 2.8x CPU performance. Up to 5x the graphics speed. Our most advanced Neural Engine for up to 11x faster machine learning. And up to 20 hours of battery life — the longest of any Mac ever. It’s our most popular pro notebook, taken to a whole new level."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac Pro 3.3GHz 12-core Intel Xeon W, Radeon Pro 580X","url":"https://www.apple.com/shop/product/G10LGLL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X","mainEntityOfPage":"https://www.apple.com/shop/product/G10LGLL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":7729.00,"sku":"G10LGLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-rack-2019?wid=2000&hei=1272&fmt=jpeg&qlt=95&.v=1605114669000","description":"Originally released December 2019 3.5GHz 8‑core Intel Xeon W processor, Turbo Boost up to 4.0GHz 48GB (6x8GB) of DDR4 ECC memory Radeon Pro 580X with 8GB of GDDR5 memory 256GB SSD storage Stainless steel frame with feet"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac 3.1GHz 6-core Intel Core i5 with Retina 5K display, 10GB Ethernet","url":"https://www.apple.com/shop/product/G0ZV7LL/A/Refurbished-27-inch-iMac-31GHz-6-core-Intel-Core-i5-with-Retina-5K-display-10GB-Ethernet","mainEntityOfPage":"https://www.apple.com/shop/product/G0ZV7LL/A/Refurbished-27-inch-iMac-31GHz-6-core-Intel-Core-i5-with-Retina-5K-display-10GB-Ethernet","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":3249.00,"sku":"G0ZV7LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-imac-27-2020?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1654865822599","description":"Originally released August 2020 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors True Tone technology 128GB of 2666MHz DDR4 memory 256GB SSD1 1080p FaceTime HD camera Radeon Pro 5300 with 4GB of GDDR6 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Gold","url":"https://www.apple.com/shop/product/FGNE3LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu-gold","mainEntityOfPage":"https://www.apple.com/shop/product/FGNE3LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu-gold","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1059.00,"sku":"FGNE3LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-macbook-air-gold-m1-202010?wid=539&hei=312&fmt=jpeg&qlt=95&.v=1634145607000","description":"Originally released November 2020|13.3-inch (diagonal) LED-backlit display with IPS technology; 2560-by-1600 native resolution at 227 pixels per inch|8GB unified memory|512GB SSD1|Touch ID sensor|720p FaceTime HD Camera"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray","url":"https://www.apple.com/shop/product/GMW2ELL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","mainEntityOfPage":"https://www.apple.com/shop/product/GMW2ELL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":2549.00,"sku":"GMW2ELL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1553797551145","description":"In addition to being a great desktop computer, Mac mini powers everything from home automation to giant render farms. And now with eighth-generation Intel quad-core and 6-core processors and Intel UHD Graphics 630, Mac mini has even more compute power for industrial-grade tasks. So whether you’re running a live concert sound engine or testing your latest iOS app, Mac mini is the shortest distance between a great idea and a great result."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac Pro 2.5GHz 28-core Intel Xeon W, Two Radeon Pro Vega II Duo, Apple Afterburner","url":"https://www.apple.com/shop/product/G0ZKLLL/A/Refurbished-Mac-Pro-25GHz-28-core-Intel-Xeon-W-Two-Radeon-Pro-Vega-II-Duo-Apple-Afterburner","mainEntityOfPage":"https://www.apple.com/shop/product/G0ZKLLL/A/Refurbished-Mac-Pro-25GHz-28-core-Intel-Xeon-W-Two-Radeon-Pro-Vega-II-Duo-Apple-Afterburner","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":41649.00,"sku":"G0ZKLLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-2019?wid=1500&hei=1250&fmt=jpeg&qlt=95&.v=1585849394561","description":"Originally released December 2019 3.3GHz 12‑core Intel Xeon W processor, Turbo Boost up to 4.4GHz \n48GB (6x8GB) of DDR4 ECC memory Two Radeon Pro Vega II with 32GB of HBM2 memory each 1TB SSD storage Stainless steel frame with feet Apple Afterburner"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac 3.1GHz 6-core Intel Core i5 with Retina 5K display","url":"https://www.apple.com/shop/product/G0VR4LL/A/Refurbished-27-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0VR4LL/A/Refurbished-27-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1869.00,"sku":"G0VR4LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-27-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087002","description":"Originally released March 2019 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 8GB of 2666MHz DDR4 memory 1TB SSD storage1 FaceTime HD camera Radeon Pro 575X"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/GMURKLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/GMURKLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":5269.00,"sku":"GMURKLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017\n27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors\n64GB of 2666MHz DDR4 ECC memory\n1TB SSD storage\n1080p FaceTime HD camera\nRadeon Pro Vega 56 graphics processor with 8GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display and Radeon Pro Vega 20","url":"https://www.apple.com/shop/product/G0VYCLL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display-and-Radeon-Pro-Vega-20","mainEntityOfPage":"https://www.apple.com/shop/product/G0VYCLL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display-and-Radeon-Pro-Vega-20","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1909.00,"sku":"G0VYCLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087778","description":"Originally released March 2019 21.5-inch (diagonal) Retina 4K display; 4096-by-2304 resolution with support for one billion colors 16GB of 2666MHz DDR4 memory 512GB SSD storage1 FaceTime HD camera Radeon Pro Vega 20"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 3.6GHz quad-core Intel Core i3 with Retina 4K display","url":"https://www.apple.com/shop/product/G0VX6LL/A/Refurbished-215-inch-iMac-36GHz-quad-core-Intel-Core-i3-with-Retina-4K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0VX6LL/A/Refurbished-215-inch-iMac-36GHz-quad-core-Intel-Core-i3-with-Retina-4K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1269.00,"sku":"G0VX6LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087778","description":"Originally released March 2019\n21.5-inch (diagonal) Retina 4K display; 4096-by-2304 resolution with support for one billion colors\n16GB of 2400MHz DDR4 memory\n256GB SSD storage1\nFaceTime HD camera\nRadeon Pro 555X"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini Apple M1 Chip with 8‑Core CPU and 8‑Core GPU, 10GB Ethernet","url":"https://www.apple.com/shop/product/G12PALL/A/Refurbished-Mac-mini-Apple-M1-Chip-with-8‑Core-CPU-and-8‑Core-GPU-10GB-Ethernet","mainEntityOfPage":"https://www.apple.com/shop/product/G12PALL/A/Refurbished-Mac-mini-Apple-M1-Chip-with-8‑Core-CPU-and-8‑Core-GPU-10GB-Ethernet","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1529.00,"sku":"G12PALL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2020?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1614364640000","description":"The Apple M1 chip takes our most versatile, do-it-all desktop into another dimension. With up to 3x faster CPU performance. Up to 6x faster graphics. And our most advanced Neural Engine for up to 15x faster machine learning. Get ready to work, play, and create on Mac mini with speed and power beyond anything you ever imagined."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 3.2GHz 8-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/G0URKLL/A/Refurbished-27-inch-iMac-Pro-32GHz-8-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0URKLL/A/Refurbished-27-inch-iMac-Pro-32GHz-8-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":4289.00,"sku":"G0URKLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 32GB of 2666MHz DDR4 ECC memory 1TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 64 graphics processor with 16GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/G0UR5LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0UR5LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":4589.00,"sku":"G0UR5LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 64GB of 2666MHz DDR4 ECC memory 1TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 56 graphics processor with 8GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 16-inch MacBook Pro Apple M1 Pro Chip with 10‑Core CPU and 16‑Core GPU - Silver","url":"https://www.apple.com/shop/product/FK1F3LL/A/refurbished-16-inch-macbook-pro-apple-m1-pro-chip-with-10‑core-cpu-and-16‑core-gpu-silver","mainEntityOfPage":"https://www.apple.com/shop/product/FK1F3LL/A/refurbished-16-inch-macbook-pro-apple-m1-pro-chip-with-10‑core-cpu-and-16‑core-gpu-silver","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":2429.00,"sku":"FK1F3LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp16-silver-m1-2021?wid=1250&hei=1200&fmt=jpeg&qlt=95&.v=1643239832000","description":"The most powerful MacBook Pro ever is here. With the blazing-fast M1 Pro or M1 Max chip — the first Apple silicon designed for pros — you get groundbreaking performance and amazing battery life. Add to that a stunning Liquid Retina XDR display, the best camera and audio ever in a Mac notebook, and all the ports you need. The first notebook of its kind, this MacBook Pro is a beast."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac 3.6GHz 10-core Intel Core i9 with Retina 5K display, 10GB Ethernet","url":"https://www.apple.com/shop/product/G11R0LL/A/Refurbished-27-inch-iMac-36GHz-10-core-Intel-Core-i9-with-Retina-5K-display-10GB-Ethernet","mainEntityOfPage":"https://www.apple.com/shop/product/G11R0LL/A/Refurbished-27-inch-iMac-36GHz-10-core-Intel-Core-i9-with-Retina-5K-display-10GB-Ethernet","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":5989.00,"sku":"G11R0LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-imac-27-2020?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1654865822599","description":"Originally released August 2020 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors True Tone technology 128GB of 2666MHz DDR4 memory 4TB SSD 1080p FaceTime HD camera Radeon Pro 5700 XT with 16GB of GDDR6 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac Pro 3.5GHz 8-core Intel Xeon W, Radeon Pro 580X","url":"https://www.apple.com/shop/product/G10K0LL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X","mainEntityOfPage":"https://www.apple.com/shop/product/G10K0LL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":5609.00,"sku":"G10K0LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-rack-2019?wid=2000&hei=1272&fmt=jpeg&qlt=95&.v=1605114669000","description":"Originally released December 20193.5GHz 8‑core Intel Xeon W processor, Turbo Boost up to 4.0GHz48GB (6x8GB) of DDR4 ECC memoryRadeon Pro 580X with 8GB of GDDR5 memory256GB SSD1 storageRack mounting rails (ships in separate box)"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac Pro 2.5GHz 28-core Intel Xeon W, Two Radeon Pro Vega II Duo, Apple Afterburner","url":"https://www.apple.com/shop/product/G0ZKMLL/A/Refurbished-Mac-Pro-25GHz-28-core-Intel-Xeon-W-Two-Radeon-Pro-Vega-II-Duo-Apple-Afterburner","mainEntityOfPage":"https://www.apple.com/shop/product/G0ZKMLL/A/Refurbished-Mac-Pro-25GHz-28-core-Intel-Xeon-W-Two-Radeon-Pro-Vega-II-Duo-Apple-Afterburner","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":42159.00,"sku":"G0ZKMLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-2019?wid=1500&hei=1250&fmt=jpeg&qlt=95&.v=1585849394561","description":"Originally released December 2019 2.5GHz 28‑core Intel Xeon W processor, Turbo Boost up to 4.4GHz 1.5TB (12x128GB) of DDR4 ECC memory Two Radeon Pro Vega II with 32GB of HBM2 memory each 4TB SSD storage Stainless steel frame with feet Apple Afterburner"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/GMURLLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/GMURLLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":5739.00,"sku":"GMURLLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017\n27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors\n64GB of 2666MHz DDR4 ECC memory\n1TB SSD storage\n1080p FaceTime HD camera\nRadeon Pro Vega 64 graphics processor with 16GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display","url":"https://www.apple.com/shop/product/G0VYZLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0VYZLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1609.00,"sku":"G0VYZLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087778","description":"Originally released March 2019 21.5-inch (diagonal) Retina 4K display; 4096-by-2304 resolution with support for one billion colors 16GB of 2666MHz DDR4 memory 256GB SSD storage1 FaceTime HD camera Radeon Pro 560X"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 5K display","url":"https://www.apple.com/shop/product/G0VQ3LL/A/Refurbished-27-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0VQ3LL/A/Refurbished-27-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1779.00,"sku":"G0VQ3LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-27-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087002","description":"Originally released March 2019 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 8GB of 2666MHz DDR4 memory 1TB SSD storage1 FaceTime HD camera Radeon Pro 570X"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display","url":"https://www.apple.com/shop/product/G0VYDLL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0VYDLL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1779.00,"sku":"G0VYDLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087778","description":"Originally released March 2019 21.5-inch (diagonal) Retina 4K display; 4096-by-2304 resolution with support for one billion colors 16GB of 2666MHz DDR4 memory 1TB SSD storage1 FaceTime HD camera Radeon Pro 560X"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini Apple M1 Chip with 8‑Core CPU and 8‑Core GPU","url":"https://www.apple.com/shop/product/FGNT3LL/A/refurbished-mac-mini-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu","mainEntityOfPage":"https://www.apple.com/shop/product/FGNT3LL/A/refurbished-mac-mini-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":759.00,"sku":"FGNT3LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2020?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1614364640000","description":"The Apple M1 chip takes our most versatile, do-it-all desktop into another dimension. With up to 3x faster CPU performance. Up to 6x faster graphics. And our most advanced Neural Engine for up to 15x faster machine learning. Get ready to work, play, and create on Mac mini with speed and power beyond anything you ever imagined."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display","url":"https://www.apple.com/shop/product/G0VY9LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0VY9LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1439.00,"sku":"G0VY9LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087778","description":"Originally released March 2019 21.5-inch (diagonal) Retina 4K display; 4096-by-2304 resolution with support for one billion colors 16GB of 2666MHz DDR4 memory 256GB SSD storage1 FaceTime HD camera Radeon Pro 560X"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini 3.6GHz quad-core Intel Core i3 - Space Gray","url":"https://www.apple.com/shop/product/FXNF2LL/A/Refurbished-Mac-mini-36GHz-quad-core-Intel-Core-i3-Space-Gray","mainEntityOfPage":"https://www.apple.com/shop/product/FXNF2LL/A/Refurbished-Mac-mini-36GHz-quad-core-Intel-Core-i3-Space-Gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":679.00,"sku":"FXNF2LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1553797551145","description":"Originally released March 20208GB of 2666MHz DDR4 SO-DIMM memory256GB PCIe-based SSD1Four Thunderbolt 3 ports (up to 40 Gbps)Intel UHD Graphics 630Gigabit Ethernet port"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/G0URALL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0URALL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":5909.00,"sku":"G0URALL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 64GB of 2666MHz DDR4 ECC memory 4TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 64 graphics processor with 16GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/G0UR6LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0UR6LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":5059.00,"sku":"G0UR6LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 64GB of 2666MHz DDR4 ECC memory 1TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 64 graphics processor with 16GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini Apple M1 Chip with 8‑Core CPU and 8‑Core GPU","url":"https://www.apple.com/shop/product/G12P7LL/A/refurbished-mac-mini-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu","mainEntityOfPage":"https://www.apple.com/shop/product/G12P7LL/A/refurbished-mac-mini-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1099.00,"sku":"G12P7LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2020?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1614364640000","description":"The Apple M1 chip takes our most versatile, do-it-all desktop into another dimension. With up to 3x faster CPU performance. Up to 6x faster graphics. And our most advanced Neural Engine for up to 15x faster machine learning. Get ready to work, play, and create on Mac mini with speed and power beyond anything you ever imagined."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 13.3-inch MacBook Pro Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Space Gray","url":"https://www.apple.com/shop/product/G11B0LL/A/refurbished-133-inch-macbook-pro-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu-space-gray","mainEntityOfPage":"https://www.apple.com/shop/product/G11B0LL/A/refurbished-133-inch-macbook-pro-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu-space-gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1229.00,"sku":"G11B0LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp13-space-m1-2020?wid=1200&hei=1200&fmt=jpeg&qlt=95&.v=1628621779000","description":"The Apple M1 chip gives the 13‑inch MacBook Pro speed and power beyond belief. With up to 2.8x CPU performance. Up to 5x the graphics speed. Our most advanced Neural Engine for up to 11x faster machine learning. And up to 20 hours of battery life — the longest of any Mac ever. It’s our most popular pro notebook, taken to a whole new level."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 14-inch MacBook Pro Apple M1 Pro Chip with 10‑Core CPU and 16‑Core GPU - Space Gray","url":"https://www.apple.com/shop/product/FKGQ3LL/A/refurbished-14-inch-macbook-pro-apple-m1-pro-chip-with-10‑core-cpu-and-16‑core-gpu-space-gray","mainEntityOfPage":"https://www.apple.com/shop/product/FKGQ3LL/A/refurbished-14-inch-macbook-pro-apple-m1-pro-chip-with-10‑core-cpu-and-16‑core-gpu-space-gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":2249.00,"sku":"FKGQ3LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp14-space-m1-2021?wid=1200&hei=1200&fmt=jpeg&qlt=95&.v=1638575247000","description":"M1 Pro takes the exceptional performance of the M1 architecture to a whole new level for pro users. Even the most ambitious projects are easily handled with up to 10 CPU cores, up to 16 GPU cores, a 16‑core Neural Engine, and dedicated encode and decode media engines that support H.264, HEVC, and ProRes codecs."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 3.2GHz 8-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/FQ2Y2LL/A/Refurbished-27-inch-iMac-Pro-32GHz-8-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/FQ2Y2LL/A/Refurbished-27-inch-iMac-Pro-32GHz-8-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":3249.00,"sku":"FQ2Y2LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 32GB of 2666MHz DDR4 ECC memory 1TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 56 graphics processor with 8GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac Pro 3.3GHz 12-core Intel Xeon W, Radeon Pro W5700X","url":"https://www.apple.com/shop/product/G143FLL/A/Refurbished-Mac-Pro-33GHz-12-core-Intel-Xeon-W-Radeon-Pro-W5700X","mainEntityOfPage":"https://www.apple.com/shop/product/G143FLL/A/Refurbished-Mac-Pro-33GHz-12-core-Intel-Xeon-W-Radeon-Pro-W5700X","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":7479.00,"sku":"G143FLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-2019?wid=1500&hei=1250&fmt=jpeg&qlt=95&.v=1585849394561","description":"Originally released December 20193.3GHz 12‑core Intel Xeon W processor, Turbo Boost up to 4.4GHz48GB (6x8GB) of DDR4 ECC memoryRadeon Pro W5700X with 16GB of GDDR6 memory1TB SSD1 storageStainless steel frame with feet"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac Pro 3.5GHz 8-core Intel Xeon W, Two Radeon Pro W5700X, Apple Afterburner","url":"https://www.apple.com/shop/product/G10TWLL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Two-Radeon-Pro-W5700X-Apple-Afterburner","mainEntityOfPage":"https://www.apple.com/shop/product/G10TWLL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Two-Radeon-Pro-W5700X-Apple-Afterburner","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":9179.00,"sku":"G10TWLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-rack-2019?wid=2000&hei=1272&fmt=jpeg&qlt=95&.v=1605114669000","description":"Originally released December 20193.5GHz 8‑core Intel Xeon W processor, Turbo Boost up to 4.0GHze48GB (6x8GB) of DDR4 ECC memoryTwo Radeon Pro W5700X with 16GB of GDDR6 memory each2TB SSD1 storageRack mounting rails (ships in separate box)Apple Afterburner"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 2.3GHz dual-core Intel Core i5","url":"https://www.apple.com/shop/product/G0TH0LL/A/Refurbished-215-inch-iMac-23GHz-dual-core-Intel-Core-i5","mainEntityOfPage":"https://www.apple.com/shop/product/G0TH0LL/A/Refurbished-215-inch-iMac-23GHz-dual-core-Intel-Core-i5","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":929.00,"sku":"G0TH0LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2017-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1499114976977","description":"Originally released June 2017 21.5-inch (diagonal) LED-backlit display 1920‑by‑1080 resolution with support for millions of colors 8GB of 2133MHz DDR4 onboard memory 1TB Fusion Drive \nFaceTime HD camera Intel Iris Plus Graphics 640"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 7‑Core GPU - Gold","url":"https://www.apple.com/shop/product/FGND3LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8‑core-cpu-and-7‑core-gpu-gold","mainEntityOfPage":"https://www.apple.com/shop/product/FGND3LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8‑core-cpu-and-7‑core-gpu-gold","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":849.00,"sku":"FGND3LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-macbook-air-gold-m1-202010?wid=539&hei=312&fmt=jpeg&qlt=95&.v=1634145607000","description":"Originally released November 2020|13.3-inch (diagonal) LED-backlit display with IPS technology; 2560-by-1600 native resolution at 227 pixels per inch|8GB unified memory|256GB SSD1|Touch ID sensor|720p FaceTime HD Camera"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray","url":"https://www.apple.com/shop/product/G0W2ULL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","mainEntityOfPage":"https://www.apple.com/shop/product/G0W2ULL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1439.00,"sku":"G0W2ULL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1553797551145","description":"In addition to being a great desktop computer, Mac mini powers everything from home automation to giant render farms. And now with eighth-generation Intel quad-core and 6-core processors and Intel UHD Graphics 630, Mac mini has even more compute power for industrial-grade tasks. So whether you’re running a live concert sound engine or testing your latest iOS app, Mac mini is the shortest distance between a great idea and a great result."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini 3.0GHz 6-core Intel Core i5 - Space Gray","url":"https://www.apple.com/shop/product/G0ZT5LL/A/Refurbished-Mac-mini-30GHz-6-core-Intel-Core-i5-Space-Gray","mainEntityOfPage":"https://www.apple.com/shop/product/G0ZT5LL/A/Refurbished-Mac-mini-30GHz-6-core-Intel-Core-i5-Space-Gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1099.00,"sku":"G0ZT5LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1553797551145","description":"Originally released March 202016GB of 2666MHz DDR4 SO-DIMM memory512GB PCIe-based SSD1Four Thunderbolt 3 ports (up to 40 Gbps)Intel UHD Graphics 630Gigabit Ethernet port"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac Pro 3.5GHz 8-core Intel Xeon W, Radeon Pro 580X","url":"https://www.apple.com/shop/product/G0W36LL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X","mainEntityOfPage":"https://www.apple.com/shop/product/G0W36LL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":6459.00,"sku":"G0W36LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-2019?wid=1500&hei=1250&fmt=jpeg&qlt=95&.v=1585849394561","description":"Originally released December 2019 3.5GHz 8‑core Intel Xeon W processor, Turbo Boost up to 4.0GHz 48GB (6x8GB) of DDR4 ECC memory Radeon Pro 580X with 8GB of GDDR5 memory 256GB SSD storage Stainless steel frame with feet"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/G0URXLL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0URXLL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":4719.00,"sku":"G0URXLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 32GB of 2666MHz DDR4 ECC memory 1TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 64 graphics processor with 16GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/G0URBLL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0URBLL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":6289.00,"sku":"G0URBLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 128GB of 2666MHz DDR4 ECC memory 2TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 56 graphics processor with 8GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/G0UR7LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0UR7LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":4929.00,"sku":"G0UR7LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 64GB of 2666MHz DDR4 ECC memory 2TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 56 graphics processor with 8GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 13.3-inch MacBook Pro Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Silver","url":"https://www.apple.com/shop/product/FYDA2LL/A/refurbished-133-inch-macbook-pro-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu-silver","mainEntityOfPage":"https://www.apple.com/shop/product/FYDA2LL/A/refurbished-133-inch-macbook-pro-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu-silver","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1059.00,"sku":"FYDA2LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp13-silver-m1-2020?wid=1200&hei=1200&fmt=jpeg&qlt=95&.v=1628621726000","description":"The Apple M1 chip gives the 13‑inch MacBook Pro speed and power beyond belief. With up to 2.8x CPU performance. Up to 5x the graphics speed. Our most advanced Neural Engine for up to 11x faster machine learning. And up to 20 hours of battery life — the longest of any Mac ever. It’s our most popular pro notebook, taken to a whole new level."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini Apple M1 Chip with 8‑Core CPU and 8‑Core GPU, 10GB Ethernet","url":"https://www.apple.com/shop/product/G12P8LL/A/Refurbished-Mac-mini-Apple-M1-Chip-with-8‑Core-CPU-and-8‑Core-GPU-10GB-Ethernet","mainEntityOfPage":"https://www.apple.com/shop/product/G12P8LL/A/Refurbished-Mac-mini-Apple-M1-Chip-with-8‑Core-CPU-and-8‑Core-GPU-10GB-Ethernet","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1189.00,"sku":"G12P8LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2020?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1614364640000","description":"The Apple M1 chip takes our most versatile, do-it-all desktop into another dimension. With up to 3x faster CPU performance. Up to 6x faster graphics. And our most advanced Neural Engine for up to 15x faster machine learning. Get ready to work, play, and create on Mac mini with speed and power beyond anything you ever imagined."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac Pro 3.5GHz 8-core Intel Xeon W, Radeon Pro 580X","url":"https://www.apple.com/shop/product/G10K2LL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X","mainEntityOfPage":"https://www.apple.com/shop/product/G10K2LL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":6289.00,"sku":"G10K2LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-rack-2019?wid=2000&hei=1272&fmt=jpeg&qlt=95&.v=1605114669000","description":"Originally released December 2019 3.5GHz 8‑core Intel Xeon W processor, Turbo Boost up to 4.0GHz 48GB (6x8GB) of DDR4 ECC memory Radeon Pro 580X with 8GB of GDDR5 memory 2TB SSD storage Stainless steel frame with feet"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 16-inch MacBook Pro Apple M1 Pro Chip with 10‑Core CPU and 16‑Core GPU - Silver","url":"https://www.apple.com/shop/product/FK1E3LL/A/refurbished-16-inch-macbook-pro-apple-m1-pro-chip-with-10‑core-cpu-and-16‑core-gpu-silver","mainEntityOfPage":"https://www.apple.com/shop/product/FK1E3LL/A/refurbished-16-inch-macbook-pro-apple-m1-pro-chip-with-10‑core-cpu-and-16‑core-gpu-silver","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":2249.00,"sku":"FK1E3LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp16-silver-m1-2021?wid=1250&hei=1200&fmt=jpeg&qlt=95&.v=1643239832000","description":"The most powerful MacBook Pro ever is here. With the blazing-fast M1 Pro or M1 Max chip — the first Apple silicon designed for pros — you get groundbreaking performance and amazing battery life. Add to that a stunning Liquid Retina XDR display, the best camera and audio ever in a Mac notebook, and all the ports you need. The first notebook of its kind, this MacBook Pro is a beast."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 2.3GHz dual-core Intel Core i5","url":"https://www.apple.com/shop/product/G0TH1LL/A/Refurbished-215-inch-iMac-23GHz-dual-core-Intel-Core-i5","mainEntityOfPage":"https://www.apple.com/shop/product/G0TH1LL/A/Refurbished-215-inch-iMac-23GHz-dual-core-Intel-Core-i5","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":929.00,"sku":"G0TH1LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2017-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1499114976977","description":"Originally released June 2017 21.5-inch (diagonal) LED-backlit display 1920‑by‑1080 resolution with support for millions of colors 8GB of 2133MHz DDR4 onboard memory 256GB SSD storage FaceTime HD camera Intel Iris Plus Graphics 640"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray","url":"https://www.apple.com/shop/product/GMW22LL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","mainEntityOfPage":"https://www.apple.com/shop/product/GMW22LL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":2459.00,"sku":"GMW22LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1553797551145","description":"In addition to being a great desktop computer, Mac mini powers everything from home automation to giant render farms. And now with eighth-generation Intel quad-core and 6-core processors and Intel UHD Graphics 630, Mac mini has even more compute power for industrial-grade tasks. So whether you’re running a live concert sound engine or testing your latest iOS app, Mac mini is the shortest distance between a great idea and a great result."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display and Radeon Pro Vega 20","url":"https://www.apple.com/shop/product/GMVYCLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display-and-Radeon-Pro-Vega-20","mainEntityOfPage":"https://www.apple.com/shop/product/GMVYCLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display-and-Radeon-Pro-Vega-20","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":2589.00,"sku":"GMVYCLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087778","description":"Originally released March 2019 21.5-inch (diagonal) Retina 4K display; 4096-by-2304 resolution with support for one billion colors 32GB of 2666MHz DDR4 memory 1TB SSD storage1 FaceTime HD camera Radeon Pro Vega 20"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac Studio Apple M1 Max Chip with 10‑Core CPU and 32‑Core GPU","url":"https://www.apple.com/shop/product/G14JALL/A/refurbished-mac-studio-apple-m1-max-chip-with-10‑core-cpu-and-32‑core-gpu","mainEntityOfPage":"https://www.apple.com/shop/product/G14JALL/A/refurbished-mac-studio-apple-m1-max-chip-with-10‑core-cpu-and-32‑core-gpu","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":2159.00,"sku":"G14JALL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-studio-202203?wid=2000&hei=1536&fmt=jpeg&qlt=95&.v=1653413024271","description":"Originally released March 2022 32GB unified memory 1TB SSD¹ Front: Two USB-C ports, one SDXC card slot Back: Four Thunderbolt 4 ports, two USB-A ports, one HDMI port, one 10Gb Ethernet port, one 3.5mm headphone jack"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display and Radeon Pro Vega 20","url":"https://www.apple.com/shop/product/G0VYQLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display-and-Radeon-Pro-Vega-20","mainEntityOfPage":"https://www.apple.com/shop/product/G0VYQLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display-and-Radeon-Pro-Vega-20","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1739.00,"sku":"G0VYQLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087778","description":"Originally released March 2019 21.5-inch (diagonal) Retina 4K display; 4096-by-2304 resolution with support for one billion colors 8GB of 2666MHz DDR4 memory 1TB Fusion Drive1 FaceTime HD camera Radeon Pro Vega 20"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 7‑Core GPU - Silver","url":"https://www.apple.com/shop/product/FGN93LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8‑core-cpu-and-7‑core-gpu-silver","mainEntityOfPage":"https://www.apple.com/shop/product/FGN93LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8‑core-cpu-and-7‑core-gpu-silver","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":849.00,"sku":"FGN93LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-macbook-air-silver-m1-202010?wid=539&hei=312&fmt=jpeg&qlt=95&.v=1634145618000","description":"Originally released November 2020|13.3-inch (diagonal) LED-backlit display with IPS technology; 2560-by-1600 native resolution at 227 pixels per inch|8GB unified memory|256GB SSD1|Touch ID sensor|720p FaceTime HD Camera"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display and Radeon Pro Vega 20","url":"https://www.apple.com/shop/product/G0VY0LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display-and-Radeon-Pro-Vega-20","mainEntityOfPage":"https://www.apple.com/shop/product/G0VY0LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display-and-Radeon-Pro-Vega-20","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1569.00,"sku":"G0VY0LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087778","description":"Originally released March 2019 21.5-inch (diagonal) Retina 4K display; 4096-by-2304 resolution with support for one billion colors 8GB of 2666MHz DDR4 memory 1TB Fusion Drive1 FaceTime HD camera Radeon Pro Vega 20"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 3.2GHz 8-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/G0URYLL/A/Refurbished-27-inch-iMac-Pro-32GHz-8-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0URYLL/A/Refurbished-27-inch-iMac-Pro-32GHz-8-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":4159.00,"sku":"G0URYLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 32GB of 2666MHz DDR4 ECC memory 2TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 56 graphics processor with 8GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac Pro 3.2GHz 16-core Intel Xeon W, Radeon Pro W6800X","url":"https://www.apple.com/shop/product/G14GQLL/A/Refurbished-Mac-Pro-32GHz-16-core-Intel-Xeon-W-Radeon-Pro-W6800X","mainEntityOfPage":"https://www.apple.com/shop/product/G14GQLL/A/Refurbished-Mac-Pro-32GHz-16-core-Intel-Xeon-W-Radeon-Pro-W6800X","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":9429.00,"sku":"G14GQLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-2019?wid=1500&hei=1250&fmt=jpeg&qlt=95&.v=1585849394561","description":"Originally released December 20193.2GHz 16‑core Intel Xeon W processor, Turbo Boost up to 4.4GHz48GB (6x8GB) of DDR4 ECC memoryRadeon Pro W6800X with 32GB of GDDR6 memory2TB SSD1 storageStainless steel frame with feet"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/G0URCLL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0URCLL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":6759.00,"sku":"G0URCLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 128GB of 2666MHz DDR4 ECC memory 2TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 64 graphics processor with 16GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini Apple M1 Chip with 8‑Core CPU and 8‑Core GPU","url":"https://www.apple.com/shop/product/G12P9LL/A/refurbished-mac-mini-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu","mainEntityOfPage":"https://www.apple.com/shop/product/G12P9LL/A/refurbished-mac-mini-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1439.00,"sku":"G12P9LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2020?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1614364640000","description":"The Apple M1 chip takes our most versatile, do-it-all desktop into another dimension. With up to 3x faster CPU performance. Up to 6x faster graphics. And our most advanced Neural Engine for up to 15x faster machine learning. Get ready to work, play, and create on Mac mini with speed and power beyond anything you ever imagined."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/G0UR8LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0UR8LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":5399.00,"sku":"G0UR8LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 64GB of 2666MHz DDR4 ECC memory 2TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 64 graphics processor with 16GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray","url":"https://www.apple.com/shop/product/G11L1LL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","mainEntityOfPage":"https://www.apple.com/shop/product/G11L1LL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1609.00,"sku":"G11L1LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1553797551145","description":"Originally released March 202032GB of 2666MHz DDR4 SO-DIMM memory512GB PCIe-based SSD1Four Thunderbolt 3 ports (up to 40 Gbps)Intel UHD Graphics 630Gigabit Ethernet port"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/G0URNLL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0URNLL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":4249.00,"sku":"G0URNLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 32GB of 2666MHz DDR4 ECC memory 1TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 56 graphics processor with 8GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac 3.6GHz 10-core Intel Core i9 with Retina 5K display","url":"https://www.apple.com/shop/product/G11PELL/A/Refurbished-27-inch-iMac-36GHz-10-core-Intel-Core-i9-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G11PELL/A/Refurbished-27-inch-iMac-36GHz-10-core-Intel-Core-i9-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":4479.00,"sku":"G11PELL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-imac-27-2020?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1654865822599","description":"Originally released August 2020 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors True Tone technology 128GB of 2666MHz DDR4 memory 2TB SSD1 1080p FaceTime HD camera Radeon Pro 5700 with 8GB of GDDR6 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray","url":"https://www.apple.com/shop/product/G0ZTXLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","mainEntityOfPage":"https://www.apple.com/shop/product/G0ZTXLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1439.00,"sku":"G0ZTXLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1553797551145","description":"Originally released March 202016GB of 2666MHz DDR4 SO-DIMM memory1TB PCIe-based SSD1Four Thunderbolt 3 ports (up to 40 Gbps)Intel UHD Graphics 630Gigabit Ethernet port"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 2.3GHz dual-core Intel Core i5","url":"https://www.apple.com/shop/product/G0TH2LL/A/Refurbished-215-inch-iMac-23GHz-dual-core-Intel-Core-i5","mainEntityOfPage":"https://www.apple.com/shop/product/G0TH2LL/A/Refurbished-215-inch-iMac-23GHz-dual-core-Intel-Core-i5","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1099.00,"sku":"G0TH2LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2017-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1499114976977","description":"Originally released June 201721.5-inch (diagonal) LED-backlit display 1920‑by‑1080 resolution with support for millions of colors16GB of 2133MHz DDR4 onboard memory256GB SSD storage1FaceTime HD cameraIntel Iris Plus Graphics 640"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display and Radeon Pro Vega 64X","url":"https://www.apple.com/shop/product/GPURMLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display-and-Radeon-Pro-Vega-64X","mainEntityOfPage":"https://www.apple.com/shop/product/GPURMLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display-and-Radeon-Pro-Vega-64X","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":8069.00,"sku":"GPURMLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 128GB of 2666MHz DDR4 ECC memory 4TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 64X graphics processor with 16GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini 3.0GHz 6-core Intel Core i5 - Space Gray","url":"https://www.apple.com/shop/product/G0ZT7LL/A/Refurbished-Mac-mini-30GHz-6-core-Intel-Core-i5-Space-Gray","mainEntityOfPage":"https://www.apple.com/shop/product/G0ZT7LL/A/Refurbished-Mac-mini-30GHz-6-core-Intel-Core-i5-Space-Gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1269.00,"sku":"G0ZT7LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1553797551145","description":"Originally released March 202016GB of 2666MHz DDR4 SO-DIMM memory1TB PCIe-based SSD1Four Thunderbolt 3 ports (up to 40 Gbps)Intel UHD Graphics 630Gigabit Ethernet port"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac Pro 2.5GHz 28-core Intel Xeon W, Two Radeon Pro Vega II Duo","url":"https://www.apple.com/shop/product/G10RXLL/A/Refurbished-Mac-Pro-25GHz-28-core-Intel-Xeon-W-Two-Radeon-Pro-Vega-II-Duo","mainEntityOfPage":"https://www.apple.com/shop/product/G10RXLL/A/Refurbished-Mac-Pro-25GHz-28-core-Intel-Xeon-W-Two-Radeon-Pro-Vega-II-Duo","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":26769.00,"sku":"G10RXLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-rack-2019?wid=2000&hei=1272&fmt=jpeg&qlt=95&.v=1605114669000","description":"Originally released December 20192.5GHz 28‑core Intel Xeon W processor, Turbo Boost up to 4.4GHz384GB (6x64GB) of DDR4 ECC memoryTwo Radeon Pro Vega II Duo with 2x32GB of HBM2 memory each4TB SSD1 storageRack mounting rails (ships in separate box)"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display","url":"https://www.apple.com/shop/product/G0VYRLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0VYRLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1439.00,"sku":"G0VYRLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087778","description":"Originally released March 2019 21.5-inch (diagonal) Retina 4K display; 4096-by-2304 resolution with support for one billion colors 8GB of 2666MHz DDR4 memory 256GB SSD storage1 FaceTime HD camera Radeon Pro 560X"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 2.3GHz 18-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/GMURDLL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/GMURDLL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":6289.00,"sku":"GMURDLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017\n27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors\n64GB of 2666MHz DDR4 ECC memory\n2TB SSD storage\n1080p FaceTime HD camera\nRadeon Pro Vega 56 graphics processor with 8GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display","url":"https://www.apple.com/shop/product/G0VY1LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0VY1LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1269.00,"sku":"G0VY1LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087778","description":"Originally released March 2019 21.5-inch (diagonal) Retina 4K display; 4096-by-2304 resolution with support for one billion colors 8GB of 2666MHz DDR4 memory 256GB SSD storage1 FaceTime HD camera Radeon Pro 560X"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac Pro 3.2GHz 16-core Intel Xeon W, Radeon Pro 580X","url":"https://www.apple.com/shop/product/G10MYLL/A/Refurbished-Mac-Pro-32GHz-16-core-Intel-Xeon-W-Radeon-Pro-580X","mainEntityOfPage":"https://www.apple.com/shop/product/G10MYLL/A/Refurbished-Mac-Pro-32GHz-16-core-Intel-Xeon-W-Radeon-Pro-580X","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":10789.00,"sku":"G10MYLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-rack-2019?wid=2000&hei=1272&fmt=jpeg&qlt=95&.v=1605114669000","description":"Originally released December 2019 3.5GHz 8‑core Intel Xeon W processor, Turbo Boost up to 4.0GHz 48GB (6x8GB) of DDR4 ECC memory Radeon Pro 580X with 8GB of GDDR5 memory 4TB SSD storage Stainless steel frame with feet"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 2.3GHz 18-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/G0URDLL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0URDLL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":5949.00,"sku":"G0URDLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 64GB of 2666MHz DDR4 ECC memory 1TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 56 graphics processor with 8GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/G0UR9LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0UR9LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":5439.00,"sku":"G0UR9LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 64GB of 2666MHz DDR4 ECC memory 4TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 56 graphics processor with 8GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac 3.6GHz 10-core Intel Core i9 with Retina 5K display, 10GB Ethernet","url":"https://www.apple.com/shop/product/G16P5LL/A/refurbished-27-inch-imac-36ghz-10-core-intel-core-i9-with-retina-5k-display-10gb-ethernet","mainEntityOfPage":"https://www.apple.com/shop/product/G16P5LL/A/refurbished-27-inch-imac-36ghz-10-core-intel-core-i9-with-retina-5k-display-10gb-ethernet","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":3759.00,"sku":"G16P5LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-imac-27-2020?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1654865822599","description":"Originally released August 2020 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors True Tone technology 8GB of 2666MHz DDR4 memory 512GB SSD1 1080p FaceTime HD camera Radeon Pro 5700 with 8GB of GDDR6 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 2.3GHz dual-core Intel Core i5","url":"https://www.apple.com/shop/product/G0TH3LL/A/refurbished-215-inch-imac-23ghz-dual-core-intel-core-i5","mainEntityOfPage":"https://www.apple.com/shop/product/G0TH3LL/A/refurbished-215-inch-imac-23ghz-dual-core-intel-core-i5","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1059.00,"sku":"G0TH3LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2017-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1499114976977","description":"Originally released June 201721.5-inch (diagonal) LED-backlit display 1920‑by‑1080 resolution with support for millions of colors16GB of 2133MHz DDR4 onboard memory1TB hard drive1FaceTime HD cameraIntel Iris Plus Graphics 640"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/GPURYLL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/GPURYLL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":5099.00,"sku":"GPURYLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 201727-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors32GB of 2666MHz DDR4 ECC memory4TB SSD storage11080p FaceTime HD cameraRadeon Pro Vega 56 graphics processor with 8GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Gold","url":"https://www.apple.com/shop/product/G12B3LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu-gold","mainEntityOfPage":"https://www.apple.com/shop/product/G12B3LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu-gold","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1399.00,"sku":"G12B3LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-macbook-air-gold-m1-202010?wid=539&hei=312&fmt=jpeg&qlt=95&.v=1634145607000","description":"Originally released November 2020|13.3-inch (diagonal) LED-backlit display with IPS technology; 2560-by-1600 native resolution at 227 pixels per inch|16GB unified memory|1TB SSD1|Touch ID sensor|720p FaceTime HD Camera"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 16-inch MacBook Pro Apple M1 Pro Chip with 10‑Core CPU and 16‑Core GPU - Space Gray","url":"https://www.apple.com/shop/product/FK183LL/A/refurbished-16-inch-macbook-pro-apple-m1-pro-chip-with-10‑core-cpu-and-16‑core-gpu-space-gray","mainEntityOfPage":"https://www.apple.com/shop/product/FK183LL/A/refurbished-16-inch-macbook-pro-apple-m1-pro-chip-with-10‑core-cpu-and-16‑core-gpu-space-gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":2249.00,"sku":"FK183LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp16-space-m1-2021?wid=1250&hei=1200&fmt=jpeg&qlt=95&.v=1643239951000","description":"The most powerful MacBook Pro ever is here. With the blazing-fast M1 Pro or M1 Max chip — the first Apple silicon designed for pros — you get groundbreaking performance and amazing battery life. Add to that a stunning Liquid Retina XDR display, the best camera and audio ever in a Mac notebook, and all the ports you need. The first notebook of its kind, this MacBook Pro is a beast."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display and Radeon Pro Vega 20","url":"https://www.apple.com/shop/product/G0VY2LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display-and-Radeon-Pro-Vega-20","mainEntityOfPage":"https://www.apple.com/shop/product/G0VY2LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display-and-Radeon-Pro-Vega-20","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1569.00,"sku":"G0VY2LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087778","description":"Originally released March 2019 21.5-inch (diagonal) Retina 4K display; 4096-by-2304 resolution with support for one billion colors 8GB of 2666MHz DDR4 memory 256GB SSD storage1 FaceTime HD camera Radeon Pro Vega 20"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini Apple M1 Chip with 8‑Core CPU and 8‑Core GPU","url":"https://www.apple.com/shop/product/FGNR3LL/A/refurbished-mac-mini-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu","mainEntityOfPage":"https://www.apple.com/shop/product/FGNR3LL/A/refurbished-mac-mini-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":589.00,"sku":"FGNR3LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2020?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1614364640000","description":"The Apple M1 chip takes our most versatile, do-it-all desktop into another dimension. With up to 3x faster CPU performance. Up to 6x faster graphics. And our most advanced Neural Engine for up to 15x faster machine learning. Get ready to work, play, and create on Mac mini with speed and power beyond anything you ever imagined."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray","url":"https://www.apple.com/shop/product/G11L3LL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","mainEntityOfPage":"https://www.apple.com/shop/product/G11L3LL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1779.00,"sku":"G11L3LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1553797551145","description":"Originally released March 202032GB of 2666MHz DDR4 SO-DIMM memory1TB PCIe-based SSD1Four Thunderbolt 3 ports (up to 40 Gbps)Intel UHD Graphics 630Gigabit Ethernet port"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac Pro 3.3GHz 12-core Intel Xeon W, Radeon Pro Vega II","url":"https://www.apple.com/shop/product/G143ULL/A/Refurbished-Mac-Pro-33GHz-12-core-Intel-Xeon-W-Radeon-Pro-Vega-II","mainEntityOfPage":"https://www.apple.com/shop/product/G143ULL/A/Refurbished-Mac-Pro-33GHz-12-core-Intel-Xeon-W-Radeon-Pro-Vega-II","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":8579.00,"sku":"G143ULL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-2019?wid=1500&hei=1250&fmt=jpeg&qlt=95&.v=1585849394561","description":"Originally released December 20193.3GHz 12‑core Intel Xeon W processor, Turbo Boost up to 4.4GHz96GB (6x16GB) of DDR4 ECC memoryRadeon Pro Vega II with 32GB of HBM2 memory1TB SSD1 storageStainless steel frame with feet"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac Pro 3.5GHz 8-core Intel Xeon W, Radeon Pro W5700X","url":"https://www.apple.com/shop/product/G1434LL/A/refurbished-mac-pro-35ghz-8-core-intel-xeon-w-radeon-pro-w5700x","mainEntityOfPage":"https://www.apple.com/shop/product/G1434LL/A/refurbished-mac-pro-35ghz-8-core-intel-xeon-w-radeon-pro-w5700x","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":6029.00,"sku":"G1434LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-2019?wid=1500&hei=1250&fmt=jpeg&qlt=95&.v=1585849394561","description":"Originally released December 20193.5GHz 8‑core Intel Xeon W processor, Turbo Boost up to 4.0GHz48GB (6x8GB) of DDR4 ECC memoryRadeon Pro W5700X with 16GB of GDDR6 memory1TB SSD1 storageStainless steel frame with feet"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac 3.1GHz 6-core Intel Core i5 with Retina 5K display","url":"https://www.apple.com/shop/product/G0ZV2LL/A/refurbished-27-inch-imac-31GHz-6-core-Intel-Core-i5-with-retina-5k-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0ZV2LL/A/refurbished-27-inch-imac-31GHz-6-core-Intel-Core-i5-with-retina-5k-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":3179.00,"sku":"G0ZV2LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-imac-27-2020?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1654865822599","description":"Originally released August 2020 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors True Tone technology 128GB of 2666MHz DDR4 memory 256GB SSD1 1080p FaceTime HD camera Radeon Pro 5300 with 4GB of GDDR6 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 2.3GHz dual-core Intel Core i5","url":"https://www.apple.com/shop/product/G0TH4LL/A/Refurbished-215-inch-iMac-23GHz-dual-core-Intel-Core-i5","mainEntityOfPage":"https://www.apple.com/shop/product/G0TH4LL/A/Refurbished-215-inch-iMac-23GHz-dual-core-Intel-Core-i5","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1099.00,"sku":"G0TH4LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2017-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1499114976977","description":"Originally released June 201721.5-inch (diagonal) LED-backlit display 1920‑by‑1080 resolution with support for millions of colors16GB of 2133MHz DDR4 onboard memory1TB Fusion Drive1FaceTime HD cameraIntel Iris Plus Graphics 640"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray","url":"https://www.apple.com/shop/product/G0W2YLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","mainEntityOfPage":"https://www.apple.com/shop/product/G0W2YLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1779.00,"sku":"G0W2YLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1553797551145","description":"In addition to being a great desktop computer, Mac mini powers everything from home automation to giant render farms. And now with eighth-generation Intel quad-core and 6-core processors and Intel UHD Graphics 630, Mac mini has even more compute power for industrial-grade tasks. So whether you’re running a live concert sound engine or testing your latest iOS app, Mac mini is the shortest distance between a great idea and a great result."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 2.3GHz 18-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/GMURFLL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/GMURFLL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":7309.00,"sku":"GMURFLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017\n27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors\n128GB of 2666MHz DDR4 ECC memory\n1TB SSD storage\n1080p FaceTime HD camera\nRadeon Pro Vega 56 graphics processor with 8GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display","url":"https://www.apple.com/shop/product/G0VYTLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0VYTLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1609.00,"sku":"G0VYTLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087778","description":"Originally released March 2019 21.5-inch (diagonal) Retina 4K display; 4096-by-2304 resolution with support for one billion colors 8GB of 2666MHz DDR4 memory 512GB SSD storage1 FaceTime HD camera Radeon Pro 560X"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac Studio Apple M1 Max Chip with 10‑Core CPU and 32‑Core GPU","url":"https://www.apple.com/shop/product/G14J9LL/A/refurbished-mac-studio-apple-m1-max-chip-with-10‑core-cpu-and-32‑core-gpu","mainEntityOfPage":"https://www.apple.com/shop/product/G14J9LL/A/refurbished-mac-studio-apple-m1-max-chip-with-10‑core-cpu-and-32‑core-gpu","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1979.00,"sku":"G14J9LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-studio-202203?wid=2000&hei=1536&fmt=jpeg&qlt=95&.v=1653413024271","description":"Originally released March 2022 32GB unified memory 512GB SSD¹ Front: Two USB-C ports, one SDXC card slot Back: Four Thunderbolt 4 ports, two USB-A ports, one HDMI port, one 10Gb Ethernet port, one 3.5mm headphone jack"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac Studio Apple M1 Max Chip with 10‑Core CPU and 24‑Core GPU","url":"https://www.apple.com/shop/product/FJMV3LL/A/refurbished-mac-studio-apple-m1-max-chip-with-10‑core-cpu-and-24‑core-gpu","mainEntityOfPage":"https://www.apple.com/shop/product/FJMV3LL/A/refurbished-mac-studio-apple-m1-max-chip-with-10‑core-cpu-and-24‑core-gpu","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1799.00,"sku":"FJMV3LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-studio-202203?wid=2000&hei=1536&fmt=jpeg&qlt=95&.v=1653413024271","description":"M1 Max brings power to tackle challenges of almost any size. Whether you’re running multiple apps, sorting and editing thousands of photos, recording and mixing professional-quality music, or discovering a new exoplanet, the screaming-fast M1 Max has your back."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 3.6GHz quad-core Intel Core i3 with Retina 4K display","url":"https://www.apple.com/shop/product/FRT32LL/A/Refurbished-215-inch-iMac-36GHz-quad-core-Intel-Core-i3-with-Retina-4K-display","mainEntityOfPage":"https://www.apple.com/shop/product/FRT32LL/A/Refurbished-215-inch-iMac-36GHz-quad-core-Intel-Core-i3-with-Retina-4K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":899.00,"sku":"FRT32LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087778","description":"Originally released March 2019\n21.5-inch (diagonal) Retina 4K display; 4096-by-2304 resolution with support for one billion colors\n8GB of 2400MHz DDR4 memory\n1TB Serial ATA Drive1\nFaceTime HD camera\nRadeon Pro 555X"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display","url":"https://www.apple.com/shop/product/G0VY3LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0VY3LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1439.00,"sku":"G0VY3LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087778","description":"Originally released March 2019 21.5-inch (diagonal) Retina 4K display; 4096-by-2304 resolution with support for one billion colors 8GB of 2666MHz DDR4 memory 512GB SSD storage1 FaceTime HD camera Radeon Pro 560X"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 14-inch MacBook Pro Apple M1 Pro Chip with 10‑Core CPU and 16‑Core GPU - Silver","url":"https://www.apple.com/shop/product/FKGT3LL/A/refurbished-14-inch-macbook-pro-apple-m1-pro-chip-with-10‑core-cpu-and-16‑core-gpu-silver","mainEntityOfPage":"https://www.apple.com/shop/product/FKGT3LL/A/refurbished-14-inch-macbook-pro-apple-m1-pro-chip-with-10‑core-cpu-and-16‑core-gpu-silver","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":2249.00,"sku":"FKGT3LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp14-silver-m1-2021?wid=1200&hei=1200&fmt=jpeg&qlt=95&.v=1638576254000","description":"M1 Pro takes the exceptional performance of the M1 architecture to a whole new level for pro users. Even the most ambitious projects are easily handled with up to 10 CPU cores, up to 16 GPU cores, a 16‑core Neural Engine, and dedicated encode and decode media engines that support H.264, HEVC, and ProRes codecs."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 3.6GHz quad-core Intel Core i3 with Retina 4K display","url":"https://www.apple.com/shop/product/G0VX1LL/A/Refurbished-215-inch-iMac-36GHz-quad-core-Intel-Core-i3-with-Retina-4K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0VX1LL/A/Refurbished-215-inch-iMac-36GHz-quad-core-Intel-Core-i3-with-Retina-4K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1099.00,"sku":"G0VX1LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087778","description":"Originally released March 2019\n21.5-inch (diagonal) Retina 4K display; 4096-by-2304 resolution with support for one billion colors\n8GB of 2400MHz DDR4 memory\n256GB SSD storage1\nFaceTime HD camera\nRadeon Pro 555X"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/G0URQLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0URQLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":4929.00,"sku":"G0URQLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 32GB of 2666MHz DDR4 ECC memory 1TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 56 graphics processor with 8GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac Pro 3.2GHz 16-core Intel Xeon W, Radeon Pro 580X","url":"https://www.apple.com/shop/product/G10MPLL/A/Refurbished-Mac-Pro-32GHz-16-core-Intel-Xeon-W-Radeon-Pro-580X","mainEntityOfPage":"https://www.apple.com/shop/product/G10MPLL/A/Refurbished-Mac-Pro-32GHz-16-core-Intel-Xeon-W-Radeon-Pro-580X","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":7989.00,"sku":"G10MPLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-rack-2019?wid=2000&hei=1272&fmt=jpeg&qlt=95&.v=1605114669000","description":"Originally released December 2019 3.5GHz 8‑core Intel Xeon W processor, Turbo Boost up to 4.0GHz 48GB (6x8GB) of DDR4 ECC memory Radeon Pro 580X with 8GB of GDDR5 memory 2TB SSD storage Stainless steel frame with feet"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini Apple M1 Chip with 8‑Core CPU and 8‑Core GPU","url":"https://www.apple.com/shop/product/G12P1LL/A/refurbished-mac-mini-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu","mainEntityOfPage":"https://www.apple.com/shop/product/G12P1LL/A/refurbished-mac-mini-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":929.00,"sku":"G12P1LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2020?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1614364640000","description":"The Apple M1 chip takes our most versatile, do-it-all desktop into another dimension. With up to 3x faster CPU performance. Up to 6x faster graphics. And our most advanced Neural Engine for up to 15x faster machine learning. Get ready to work, play, and create on Mac mini with speed and power beyond anything you ever imagined."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 3.2GHz 8-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/G0UR0LL/A/Refurbished-27-inch-iMac-Pro-32GHz-8-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0UR0LL/A/Refurbished-27-inch-iMac-Pro-32GHz-8-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":4629.00,"sku":"G0UR0LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 64GB of 2666MHz DDR4 ECC memory 1TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 64 graphics processor with 16GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac 3.6GHz 10-core Intel Core i9 with Retina 5K display","url":"https://www.apple.com/shop/product/G11QULL/A/Refurbished-27-inch-iMac-36GHz-10-core-Intel-Core-i9-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G11QULL/A/Refurbished-27-inch-iMac-36GHz-10-core-Intel-Core-i9-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":4329.00,"sku":"G11QULL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-imac-27-2020?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1654865822599","description":"Originally released August 2020 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors True Tone technology 128GB of 2666MHz DDR4 memory 1TB SSD1 1080p FaceTime HD camera Radeon Pro 5700 XT with 16GB of GDDR6 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 14-inch MacBook Pro Apple M1 Max Chip with 10‑Core CPU and 32‑Core GPU - Space Gray","url":"https://www.apple.com/shop/product/G15HKLL/A/refurbished-14-inch-macbook-pro-apple-m1-max-chip-with-10‑core-cpu-and-32‑core-gpu-space-gray","mainEntityOfPage":"https://www.apple.com/shop/product/G15HKLL/A/refurbished-14-inch-macbook-pro-apple-m1-max-chip-with-10‑core-cpu-and-32‑core-gpu-space-gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":3329.00,"sku":"G15HKLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp14-space-m1-2021?wid=1200&hei=1200&fmt=jpeg&qlt=95&.v=1638575247000","description":"M1 Pro takes the exceptional performance of the M1 architecture to a whole new level for pro users. Even the most ambitious projects are easily handled with up to 10 CPU cores, up to 16 GPU cores, a 16‑core Neural Engine, and dedicated encode and decode media engines that support H.264, HEVC, and ProRes codecs."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray","url":"https://www.apple.com/shop/product/GMW2LLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","mainEntityOfPage":"https://www.apple.com/shop/product/GMW2LLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1609.00,"sku":"GMW2LLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1553797551145","description":"In addition to being a great desktop computer, Mac mini powers everything from home automation to giant render farms. And now with eighth-generation Intel quad-core and 6-core processors and Intel UHD Graphics 630, Mac mini has even more compute power for industrial-grade tasks. So whether you’re running a live concert sound engine or testing your latest iOS app, Mac mini is the shortest distance between a great idea and a great result."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray","url":"https://www.apple.com/shop/product/GMW2ALL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","mainEntityOfPage":"https://www.apple.com/shop/product/GMW2ALL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1869.00,"sku":"GMW2ALL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1553797551145","description":"In addition to being a great desktop computer, Mac mini powers everything from home automation to giant render farms. And now with eighth-generation Intel quad-core and 6-core processors and Intel UHD Graphics 630, Mac mini has even more compute power for industrial-grade tasks. So whether you’re running a live concert sound engine or testing your latest iOS app, Mac mini is the shortest distance between a great idea and a great result."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray","url":"https://www.apple.com/shop/product/G0ZTPLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","mainEntityOfPage":"https://www.apple.com/shop/product/G0ZTPLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1099.00,"sku":"G0ZTPLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1553797551145","description":"Originally released March 20208GB of 2666MHz DDR4 SO-DIMM memory512GB PCIe-based SSD1Four Thunderbolt 3 ports (up to 40 Gbps)Intel UHD Graphics 630Gigabit Ethernet port"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac Pro 3.5GHz 8-core Intel Xeon W, Radeon Pro 580X","url":"https://www.apple.com/shop/product/G0W30LL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X","mainEntityOfPage":"https://www.apple.com/shop/product/G0W30LL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":5179.00,"sku":"G0W30LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-2019?wid=1500&hei=1250&fmt=jpeg&qlt=95&.v=1585849394561","description":"Originally released December 2019 3.5GHz 8‑core Intel Xeon W processor, Turbo Boost up to 4.0GHz 48GB (6x8GB) of DDR4 ECC memory Radeon Pro 580X with 8GB of GDDR5 memory 256GB SSD storage Stainless steel frame with feet"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Space Gray","url":"https://www.apple.com/shop/product/FGN73LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu-space-gray","mainEntityOfPage":"https://www.apple.com/shop/product/FGN73LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu-space-gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1059.00,"sku":"FGN73LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-macbook-air-space-gray-m1-202010?wid=539&hei=312&fmt=jpeg&qlt=95&.v=1634145627000","description":"Originally released November 2020|13.3-inch (diagonal) LED-backlit display with IPS technology; 2560-by-1600 native resolution at 227 pixels per inch|8GB unified memory|512GB SSD1|Touch ID sensor|720p FaceTime HD Camera"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/G0URGLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0URGLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":5609.00,"sku":"G0URGLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 64GB of 2666MHz DDR4 ECC memory 2TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 56 graphics processor with 8GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 16-inch MacBook Pro Apple M1 Max Chip with 10‑Core CPU and 32‑Core GPU - Silver","url":"https://www.apple.com/shop/product/FK1H3LL/A/refurbished-16-inch-macbook-pro-apple-m1-max-chip-with-10‑core-cpu-and-32‑core-gpu-silver","mainEntityOfPage":"https://www.apple.com/shop/product/FK1H3LL/A/refurbished-16-inch-macbook-pro-apple-m1-max-chip-with-10‑core-cpu-and-32‑core-gpu-silver","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":3149.00,"sku":"FK1H3LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp16-silver-m1-2021?wid=1250&hei=1200&fmt=jpeg&qlt=95&.v=1643239832000","description":"The most powerful MacBook Pro ever is here. With the blazing-fast M1 Pro or M1 Max chip — the first Apple silicon designed for pros — you get groundbreaking performance and amazing battery life. Add to that a stunning Liquid Retina XDR display, the best camera and audio ever in a Mac notebook, and all the ports you need. The first notebook of its kind, this MacBook Pro is a beast."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 14-inch MacBook Pro Apple M1 Max Chip with 10‑Core CPU and 32‑Core GPU - Space Gray","url":"https://www.apple.com/shop/product/G15HLLL/A/refurbished-14-inch-macbook-pro-apple-m1-max-chip-with-10‑core-cpu-and-32‑core-gpu-space-gray","mainEntityOfPage":"https://www.apple.com/shop/product/G15HLLL/A/refurbished-14-inch-macbook-pro-apple-m1-max-chip-with-10‑core-cpu-and-32‑core-gpu-space-gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":3689.00,"sku":"G15HLLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp14-space-m1-2021?wid=1200&hei=1200&fmt=jpeg&qlt=95&.v=1638575247000","description":"M1 Pro takes the exceptional performance of the M1 architecture to a whole new level for pro users. Even the most ambitious projects are easily handled with up to 10 CPU cores, up to 16 GPU cores, a 16‑core Neural Engine, and dedicated encode and decode media engines that support H.264, HEVC, and ProRes codecs."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/GMURHLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/GMURHLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":5399.00,"sku":"GMURHLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017\n27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors\n32GB of 2666MHz DDR4 ECC memory\n1TB SSD storage\n1080p FaceTime HD camera\nRadeon Pro Vega 64 graphics processor with 16GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac Studio Apple M1 Max Chip with 10‑Core CPU and 24‑Core GPU","url":"https://www.apple.com/shop/product/G14J0LL/A/refurbished-mac-studio-apple-m1-max-chip-with-10‑core-cpu-and-24‑core-gpu","mainEntityOfPage":"https://www.apple.com/shop/product/G14J0LL/A/refurbished-mac-studio-apple-m1-max-chip-with-10‑core-cpu-and-24‑core-gpu","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1979.00,"sku":"G14J0LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-studio-202203?wid=2000&hei=1536&fmt=jpeg&qlt=95&.v=1653413024271","description":"M1 Max brings power to tackle challenges of almost any size. Whether you’re running multiple apps, sorting and editing thousands of photos, recording and mixing professional-quality music, or discovering a new exoplanet, the screaming-fast M1 Max has your back."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display","url":"https://www.apple.com/shop/product/G0VY5LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0VY5LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1609.00,"sku":"G0VY5LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087778","description":"Originally released March 2019 21.5-inch (diagonal) Retina 4K display; 4096-by-2304 resolution with support for one billion colors 8GB of 2666MHz DDR4 memory 1TB SSD storage1 FaceTime HD camera Radeon Pro 560X"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini 3.6GHz quad-core Intel Core i3 - Space Gray","url":"https://www.apple.com/shop/product/G0W18LL/A/Refurbished-Mac-mini-36GHz-quad-core-Intel-Core-i3-Space-Gray","mainEntityOfPage":"https://www.apple.com/shop/product/G0W18LL/A/Refurbished-Mac-mini-36GHz-quad-core-Intel-Core-i3-Space-Gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1439.00,"sku":"G0W18LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1553797551145","description":"In addition to being a great desktop computer, Mac mini powers everything from home automation to giant render farms. And now with eighth-generation Intel quad-core and 6-core processors and Intel UHD Graphics 630, Mac mini has even more compute power for industrial-grade tasks. So whether you’re running a live concert sound engine or testing your latest iOS app, Mac mini is the shortest distance between a great idea and a great result."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Silver","url":"https://www.apple.com/shop/product/FGNA3LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu-silver","mainEntityOfPage":"https://www.apple.com/shop/product/FGNA3LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu-silver","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1059.00,"sku":"FGNA3LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-macbook-air-silver-m1-202010?wid=539&hei=312&fmt=jpeg&qlt=95&.v=1634145618000","description":"Originally released November 2020|13.3-inch (diagonal) LED-backlit display with IPS technology; 2560-by-1600 native resolution at 227 pixels per inch|8GB unified memory|512GB SSD1|Touch ID sensor|720p FaceTime HD Camera"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 3.6GHz quad-core Intel Core i3 with Retina 4K display","url":"https://www.apple.com/shop/product/G0VX3LL/A/Refurbished-215-inch-iMac-36GHz-quad-core-Intel-Core-i3-with-Retina-4K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0VX3LL/A/Refurbished-215-inch-iMac-36GHz-quad-core-Intel-Core-i3-with-Retina-4K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1439.00,"sku":"G0VX3LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087778","description":"Originally released March 2019\n21.5-inch (diagonal) Retina 4K display; 4096-by-2304 resolution with support for one billion colors\n8GB of 2400MHz DDR4 memory\n1TB SSD storage1\nFaceTime HD camera\nRadeon Pro 555X"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 2.3GHz 18-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/G0URSLL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0URSLL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":6419.00,"sku":"G0URSLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 64GB of 2666MHz DDR4 ECC memory 1TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 64 graphics processor with 16GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display","url":"https://www.apple.com/shop/product/G0URHLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display","mainEntityOfPage":"https://www.apple.com/shop/product/G0URHLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":6079.00,"sku":"G0URHLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 64GB of 2666MHz DDR4 ECC memory 2TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 64 graphics processor with 16GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 13.3-inch MacBook Pro Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Space Gray","url":"https://www.apple.com/shop/product/FYD92LL/A/refurbished-133-inch-macbook-pro-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu-space-gray","mainEntityOfPage":"https://www.apple.com/shop/product/FYD92LL/A/refurbished-133-inch-macbook-pro-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu-space-gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1229.00,"sku":"FYD92LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp13-space-m1-2020?wid=1200&hei=1200&fmt=jpeg&qlt=95&.v=1628621779000","description":"The Apple M1 chip gives the 13‑inch MacBook Pro speed and power beyond belief. With up to 2.8x CPU performance. Up to 5x the graphics speed. Our most advanced Neural Engine for up to 11x faster machine learning. And up to 20 hours of battery life — the longest of any Mac ever. It’s our most popular pro notebook, taken to a whole new level."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac 3.8GHz 8-core Intel Core i7 with Retina 5K display, 10GB Ethernet","url":"https://www.apple.com/shop/product/G16P9LL/A/refurbished-27-inch-imac-38ghz-8-core-intel-core-i7-with-retina-5k-display-10gb-ethernet","mainEntityOfPage":"https://www.apple.com/shop/product/G16P9LL/A/refurbished-27-inch-imac-38ghz-8-core-intel-core-i7-with-retina-5k-display-10gb-ethernet","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":3679.00,"sku":"G16P9LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-imac-27-2020?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1654865822599","description":"If you can dream it, you can do it on iMac. It’s beautifully designed, incredibly intuitive, and packed with powerful tools that let you take any idea to the next level. And the new 27-inch model elevates the experience in every way, with faster processors and graphics, expanded memory and storage, enhanced audio and video capabilities, and an even more stunning Retina 5K display. It’s the desktop that does it all — better and faster than ever."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac Pro 3.2GHz 16-core Intel Xeon W, Radeon Pro 580X","url":"https://www.apple.com/shop/product/G0ZDFLL/A/Refurbished-Mac-Pro-32GHz-16-core-Intel-Xeon-W-Radeon-Pro-580X","mainEntityOfPage":"https://www.apple.com/shop/product/G0ZDFLL/A/Refurbished-Mac-Pro-32GHz-16-core-Intel-Xeon-W-Radeon-Pro-580X","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":8159.00,"sku":"G0ZDFLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-2019?wid=1500&hei=1250&fmt=jpeg&qlt=95&.v=1585849394561","description":"Originally released December 2019 3.2GHz 16‑core Intel Xeon W processor, Turbo Boost up to 4.4GHz 48GB (6x8GB) of DDR4 ECC memory Radeon Pro 580X with 8GB of GDDR5 memory 1TB SSD storage Stainless steel frame with feet"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display","url":"https://www.apple.com/shop/product/GMVY3LL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display","mainEntityOfPage":"https://www.apple.com/shop/product/GMVY3LL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1949.00,"sku":"GMVY3LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087778","description":"Originally released March 2019 21.5-inch (diagonal) Retina 4K display; 4096-by-2304 resolution with support for one billion colors 16GB of 2666MHz DDR4 memory 1TB SSD storage1 FaceTime HD camera Radeon Pro 560X"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display and Radeon Pro Vega 20","url":"https://www.apple.com/shop/product/G0VY6LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display-and-Radeon-Pro-Vega-20","mainEntityOfPage":"https://www.apple.com/shop/product/G0VY6LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display-and-Radeon-Pro-Vega-20","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1909.00,"sku":"G0VY6LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=1000&hei=1000&fmt=jpeg&qlt=95&.v=1559961087778","description":"Originally released March 2019 21.5-inch (diagonal) Retina 4K display; 4096-by-2304 resolution with support for one billion colors 8GB of 2666MHz DDR4 memory 1TB SSD storage1 FaceTime HD camera Radeon Pro Vega 20"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 13.3-inch MacBook Pro Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Silver","url":"https://www.apple.com/shop/product/FYDC2LL/A/refurbished-133-inch-macbook-pro-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu-silver","mainEntityOfPage":"https://www.apple.com/shop/product/FYDC2LL/A/refurbished-133-inch-macbook-pro-apple-m1-chip-with-8‑core-cpu-and-8‑core-gpu-silver","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":1229.00,"sku":"FYDC2LL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp13-silver-m1-2020?wid=1200&hei=1200&fmt=jpeg&qlt=95&.v=1628621726000","description":"The Apple M1 chip gives the 13‑inch MacBook Pro speed and power beyond belief. With up to 2.8x CPU performance. Up to 5x the graphics speed. Our most advanced Neural Engine for up to 11x faster machine learning. And up to 20 hours of battery life — the longest of any Mac ever. It’s our most popular pro notebook, taken to a whole new level."}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray","url":"https://www.apple.com/shop/product/G11LBLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","mainEntityOfPage":"https://www.apple.com/shop/product/G11LBLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":2459.00,"sku":"G11LBLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=1000&hei=410&fmt=jpeg&qlt=95&.v=1553797551145","description":"Originally released March 202064GB of 2666MHz DDR4 SO-DIMM memory2TB PCIe-based SSD1Four Thunderbolt 3 ports (up to 40 Gbps)Intel UHD Graphics 630Gigabit Ethernet port"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"Product","name":"Refurbished 27-inch iMac Pro 2.3GHz 18-core Intel Xeon W with Retina 5K display and Radeon Pro Vega 64X","url":"https://www.apple.com/shop/product/GNURZLL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display-and-Radeon-Pro-Vega-64X","mainEntityOfPage":"https://www.apple.com/shop/product/GNURZLL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display-and-Radeon-Pro-Vega-64X","brand":{"@type":"Organization","name":"Apple"},"offers":[{"@type":"Offer","priceCurrency":"USD","price":6879.00,"sku":"GNURZLL/A"}],"image":"https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=600&hei=600&fmt=jpeg&qlt=95&.v=1589235413137","description":"Originally released December 2017 27-inch (diagonal) Retina 5K display; 5120-by-2880 resolution with support for one billion colors 64GB of 2666MHz DDR4 ECC memory 2TB SSD storage 1080p FaceTime HD camera Radeon Pro Vega 64X graphics processor with 16GB of HBM2 memory"}</script>
+    <script
+        type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":"1","name":"Refurbished Mac"}]}</script>
+
+
+
+    <script type="application/json"
+        id="metrics">{"config":{"asMetrics":{"dataMule":"v1","graffitiEnabled":false,"useInitializeArgs":false,"enableSendBeacon":["userInteraction"]},"omniture":{"account":["applestoreww"],"trackingServer":"securemetrics.apple.com","linkInternalFilters":["javascript:","store.apple.com","secure.store.apple.com","secure1.store.apple.com","secure2.store.apple.com","epp.apple.com","secure1.epp.apple.com","storeint.apple.com","secure1.storeint.apple.com","www.apple.com","#"],"internalDomains":["store.apple.com","secure.store.apple.com","secure1.store.apple.com","epp.apple.com","storeint.apple.com","downloads.apple.com","downloads.apple.com","www.apple.com"]},"global":{"cookieDomain":"apple.com"}},"data":{"node":"standard/home/refurbished/mac","properties":{"isHomePage":false,"encryptedStoreId":"wHF2F2PHCCCX72KDY","computedPageName":"AOS: home/refurbished/mac","serverName":"m5048560","hier1":"home/refurbished/mac","characterSetForCountry":"UTF-8","currencyCode":"USD","computedChannel":"AOS: home/refurbished","crossSegmentTrackingVariable":"AOS: US Consumer: home/refurbished/mac","storeSegmentVariable":"AOS: US Consumer","storeFrontId":"10078","computedCustomStoreName":"AOS: US Consumer","langAttribute":"en-us","evarDataNodesEnabled":true},"currency":"USD","area":"shop"}}</script>
+
+
+
+
+    <script>
+        if (/(iPad).*OS ([6-9]|[1-9][0-9]).*AppleWebKit.*Mobile.*Safari/.test(navigator.userAgent)) {
+            var headNode = document.getElementsByTagName("head")[0];
+            var sbNode = document.createElement('meta');
+            var url = decodeURI("https://www.apple.com/shop/refurbished/mac");
+            var ses = "; " + document.cookie;
+            var sesParts = ses.split("; s_vi=");
+            ses = sesParts.length == 2 ? sesParts.pop().split(";").shift() : '';
+            if (ses !== '') {
+                url += url.indexOf('?') >= 0 ? '&' : '?';
+                url += 'ses=' + encodeURI(ses);
+            }
+            sbNode.name = 'apple-itunes-app';
+            sbNode.content = 'app-id=375380948, app-argument=' + url;
+            headNode.appendChild(sbNode);
+
+        }
+        else if (/(iPhone|iPod).*OS ([6-9]|[1-9][0-9]).*AppleWebKit.*Mobile.*Safari/.test(navigator.userAgent)) {
+            var headNode = document.getElementsByTagName("head")[0];
+            var sbNode = document.createElement('meta');
+            var url = decodeURI("https://www.apple.com/shop/refurbished/mac");
+            var ses = "; " + document.cookie;
+            var sesParts = ses.split("; s_vi=");
+            ses = sesParts.length == 2 ? sesParts.pop().split(";").shift() : '';
+            if (ses !== '') {
+                url += url.indexOf('?') >= 0 ? '&' : '?';
+                url += 'ses=' + encodeURI(ses);
+            }
+            sbNode.name = 'apple-itunes-app';
+            sbNode.content = 'app-id=375380948, app-argument=' + url;
+            headNode.appendChild(sbNode);
+
+        }
+    </script>
+
+
+
+
+
+
+
+
+
+    <script>
+        window.asUnsupportedBrowserUrl = "https://www.apple.com/shop/unsupported";
+    </script>
+
+
+    <script>
+        //replace nojs class with js on html element
+        (function (html) {
+            html.className = html.className.replace(/\bnojs\b/, 'js')
+        })(document.documentElement);
+    </script>
+
+    <link rel="stylesheet"
+        href="https://store.storeimages.cdn-apple.com/4982/store.apple.com/shop/rs-external/rel/us/external.css"
+        media="screen, print" />
+    <link rel="stylesheet"
+        href="https://store.storeimages.cdn-apple.com/4982/store.apple.com/shop/rs-globalelements/dist/us/globalelements.css"
+        media="screen, print" />
+
+    <link rel="stylesheet"
+        href="https://store.storeimages.cdn-apple.com/4982/store.apple.com/shop/rs-accessories/2/dist/refurb-category.css"
+        media="screen, print" />
+
+    <link rel="stylesheet"
+        href="https://store.storeimages.cdn-apple.com/4982/store.apple.com/shop/Catalog/global/css/dd/program/refurb.css"
+        media="screen, print" />
+
+    <link rel="stylesheet" href="https://www.apple.com/wss/fonts?families=SF+Pro,v3:200,300,400,500,600|SF+Pro+Icons,v3"
+        media="" />
+
+
+    <script>
+        window.irOn = true;
+    </script>
+
+    <script>
+        window.ECHO_CONFIG = {
+            metadata: {
+                environment: "",
+                sf: "us",
+                segment: "Consumer",
+                locale: "en-us",
+                referer: document.referrer
+            },
+            config: {
+                "app": "com.apple.www.Store",
+                "delaySendingPageViewDataMS": 500,
+                "nonEssentialEventSampleRatePct": 1.0,
+                "performanceMeasurePollingIntervalMS": 1000,
+                "performanceMeasuresToReport": "".split(','),
+                "resourceDisallowedResourceList": "securemetrics.apple.com".split(','),
+                "resourcePollingIntervalMS": 2000,
+                "sendErrors": true,
+                "sendPageViewData": true,
+                "sendResourceData": true,
+                "url": "https://xp.apple.com/report/2/xp_aos_clientperf"
+            }
+        };
+    </script>
+
+    <script src="https://store.storeimages.cdn-apple.com/4982/store.apple.com/shop/rs-echo/3/dist/echo-nomodule.min.js"
+        nomodule></script>
+    <script
+        src="https://store.storeimages.cdn-apple.com/4982/store.apple.com/shop/rs-external/rel/unsupportedBrowser.min.js"
+        nomodule></script>
+    <script src="https://store.storeimages.cdn-apple.com/4982/store.apple.com/shop/rs-echo/3/dist/echo.min.js"
+        type="module" async></script>
+    <script
+        src="https://store.storeimages.cdn-apple.com/4982/store.apple.com/shop/rs-external/rel/external.js"></script>
+    <script
+        src="https://store.storeimages.cdn-apple.com/4982/store.apple.com/shop/rs-vendor/1/dist/react@17.0.1/umd/react.production.min.js"></script>
+    <script
+        src="https://store.storeimages.cdn-apple.com/4982/store.apple.com/shop/rs-vendor/1/dist/react-dom@17.0.1/umd/react-dom.production.min.js"></script>
+    <script
+        src="https://store.storeimages.cdn-apple.com/4982/store.apple.com/shop/rs-globalelements/dist/globalelements.js"></script>
+    <script
+        src="https://store.storeimages.cdn-apple.com/4982/store.apple.com/shop/rs-accessories/2/dist/refurb-category.js"></script>
+
+
+
+
+
+    <script>
+        window.atServerDomain = "securemvt.apple.com";
+        window.astexEndpoint = "https://www.apple.com/shop/experience-meta";
+        window.astexLocalStorageKey = "as_tex";
+    </script>
+    <script src="https://store.storeimages.cdn-apple.com/4982/store.apple.com/shop/rs-external/rel/at.js"></script>
+
+
+    <script>
+        window.chatConfig = { "chat": { "page": [{ "name": "WEB_CHAT_COUNTRY", "value": "us" }, { "name": "WEB_CHAT_LANGUAGE", "value": "en" }, { "name": "WEB_CHAT_ORDERNUMBER", "value": null }, { "name": "WEB_CHAT_GEO", "value": "amr" }, { "name": "WEB_CHAT_SEGMENT", "value": "consumer" }, { "name": "WEB_CHAT_SECTION", "value": "product selection" }, { "name": "WEB_CHAT_SUBSECTION", "value": "mac" }, { "name": "WEB_CHAT_REFER", "value": null }, { "name": "WEB_CHAT_APP", "value": "AOS" }, { "name": "WEB_CHAT_PAGE", "value": "AOS: home/refurbished/mac" }, { "name": "url", "value": "https://contactretail.apple.com" }] } };
+    </script>
+
+    <script></script>
+
+
+
+    <script>
+        if (!/dssid2/.test(document.cookie) || !/as_dc/.test(document.cookie)) {
+            Event.onDomReady(function () {
+                var ie = document.createElement("IMG");
+                ie.src = '/shop/dc';
+                ie.width = ie.height = 1;
+                ie.style.display = "none";
+                ie.alt = "";
+                document.body.appendChild(ie);
+            });
+        }
+    </script>
+
+
+
+
+
+</head>
+
+
+<body class="as-theme-light-heroimage rf-refurb-category">
+    <script>
+        window.as = window.as || {};
+        window.as.isFlex = true;
+    </script>
+    <div class="metrics">
+        <noscript>
+            <img src="https://securemetrics.apple.com/b/ss/applestoreww/1/H.8--NS/0?pageName=No-Script:AOS%3A+home%2Frefurbished%2Fmac"
+                height="1" width="1" alt="" />
+        </noscript>
+
+
+
+        <script></script>
+
+
+
+
+        <script>
+            window.asMetrics.initialize();
+        </script>
+
+
+    </div>
+
+
+
+
+    <script>
+        if (!/dssid2/.test(document.cookie) || !/as_dc/.test(document.cookie)) {
+            Event.onDomReady(function () {
+                var ie = document.createElement("IMG");
+                ie.src = '/shop/dc';
+                ie.width = ie.height = 1;
+                ie.style.display = "none";
+                ie.alt = "";
+                document.body.appendChild(ie);
+            });
+        }
+    </script>
+
+
+
+
+
+    <script>
+        if (window.asMicrodata) {
+            window.asMicrodata.enableUpdateSeo();
+            window.asMicrodata.updateSeoUrl('/shop/updateSEO');
+        }
+    </script>
+
+
+    <script>
+        window.NAMED_ASSETS = { "refurb_filter": "Filter", "refurb_close": "Close", "a11yPageLoading": "New page loading", "refurb_paginationPreviousButton": "previous page", "refurb_pagination": "pagination", "refurb_fetching": "Fetching...", "refurb_sortLabel": "Sort By:", "refurb_paginationDelimiter": "of", "refurb_error": "Error message", "refurb_noProductsMessage": "The product you’re looking for is currently unavailable. Please try again later.<br /><a href=\"/shop/refurbished\" data-slot-name=\"namedAssets\" data-feature-name=\"Astro Link\" data-display-name=\"AOS: home/refurbished\" class=\"more\">Continue Shopping</a>", "refurb_a11yHeader": "Browse Products", "refurb_reset": "Reset", "refurb_confirm": "Done", "refurb_paginationNextButton": "next page", "a11yPageLoadingDone": "Loading complete" };
+    </script>
+
+
+    <div id="page">
+
+        <meta name="ac-gn-store-key" content="SJHJUH4YFCTTPD4F4" />
+        <meta name="ac-gn-segmentbar-redirect" content="true" />
+
+        <aside id="ac-gn-segmentbar" class="ac-gn-segmentbar" lang="en-US" dir="ltr"
+            data-strings="{ 'exit': 'Exit', 'view': '{%STOREFRONT%} Store Home', 'segments': { 'smb': 'Business Store Home', 'eduInd': 'Education Store Home', 'other': 'Store Home' } }">
+        </aside>
+        <input type="checkbox" id="ac-gn-menustate" class="ac-gn-menustate" />
+        <nav id="ac-globalnav" class="no-js" role="navigation" aria-label="Global" data-hires="false"
+            data-analytics-region="global nav" lang="en-US" dir="ltr" data-www-domain="www.apple.com"
+            data-store-locale="us" data-store-root-path="/us" data-store-api="https://www.apple.com/shop/bag/status"
+            data-search-locale="en_US" data-search-suggestions-api="/search-services/suggestions/"
+            data-search-defaultlinks-api="/search-services/suggestions/defaultlinks/">
+            <div class="ac-gn-content">
+                <ul class="ac-gn-header">
+                    <li class="ac-gn-item ac-gn-menuicon">
+                        <a href="#ac-gn-menustate" role="button" class="ac-gn-menuanchor ac-gn-menuanchor-open"
+                            id="ac-gn-menuanchor-open">
+                            <span class="ac-gn-menuanchor-label">Global Nav Open Menu</span>
+                        </a>
+                        <a href="#" role="button" class="ac-gn-menuanchor ac-gn-menuanchor-close"
+                            id="ac-gn-menuanchor-close">
+                            <span class="ac-gn-menuanchor-label">Global Nav Close Menu</span>
+                        </a>
+                        <label class="ac-gn-menuicon-label" for="ac-gn-menustate" aria-hidden="true">
+                            <span class="ac-gn-menuicon-bread ac-gn-menuicon-bread-top">
+                                <span class="ac-gn-menuicon-bread-crust ac-gn-menuicon-bread-crust-top"></span>
+                            </span>
+                            <span class="ac-gn-menuicon-bread ac-gn-menuicon-bread-bottom">
+                                <span class="ac-gn-menuicon-bread-crust ac-gn-menuicon-bread-crust-bottom"></span>
+                            </span>
+                        </label>
+                    </li>
+                    <li class="ac-gn-item ac-gn-apple">
+                        <a class="ac-gn-link ac-gn-link-apple " href="https://www.apple.com/"
+                            data-analytics-title="apple home" id="ac-gn-firstfocus-small">
+                            <span class="ac-gn-link-text">Apple</span>
+                        </a>
+                    </li>
+                    <li class="ac-gn-item ac-gn-bag ac-gn-bag-small" id="ac-gn-bag-small">
+                        <div class="ac-gn-bag-wrapper">
+                            <a class="ac-gn-link ac-gn-link-bag " href="/shop/bag" data-analytics-title="bag"
+                                data-analytics-click="bag" aria-label="Shopping Bag"
+                                data-string-badge="Shopping Bag with item count :">
+                                <span class="ac-gn-link-text">Shopping Bag</span>
+                            </a>
+                            <span class="ac-gn-bag-badge" aria-hidden="true" data-analytics-title="bag"
+                                data-analytics-click="bag">
+                                <span class="ac-gn-bag-badge-separator"></span>
+                                <span class="ac-gn-bag-badge-number"></span>
+                                <span class="ac-gn-bag-badge-unit">+</span>
+                            </span>
+                        </div>
+                        <span class="ac-gn-bagview-caret ac-gn-bagview-caret-large"></span>
+                    </li>
+                </ul>
+                <div class="ac-gn-search-placeholder-container" role="search">
+                    <div class="ac-gn-search ac-gn-search-small">
+                        <a id="ac-gn-link-search-small" class="ac-gn-link" href="/us/search"
+                            data-analytics-title="search" data-analytics-intrapage-link aria-label="Search apple.com">
+                            <div class="ac-gn-search-placeholder-bar">
+                                <div class="ac-gn-search-placeholder-input">
+                                    <div class="ac-gn-search-placeholder-input-text" aria-hidden="true">
+                                        <div class="ac-gn-link-search ac-gn-search-placeholder-input-icon"></div>
+                                        <span class="ac-gn-search-placeholder">Search apple.com</span>
+                                    </div>
+                                </div>
+                                <div
+                                    class="ac-gn-searchview-close ac-gn-searchview-close-small ac-gn-search-placeholder-searchview-close">
+                                    <span class="ac-gn-searchview-close-cancel" aria-hidden="true">Cancel</span>
+                                </div>
+                            </div>
+                        </a>
+                    </div>
+                </div>
+                <ul class="ac-gn-list">
+                    <li class="ac-gn-item ac-gn-apple">
+                        <a class="ac-gn-link ac-gn-link-apple " href="https://www.apple.com/"
+                            data-analytics-title="apple home" id="ac-gn-firstfocus">
+                            <span class="ac-gn-link-text">Apple</span>
+                        </a>
+                    </li>
+                    <li class="ac-gn-item ac-gn-item-menu ac-gn-store">
+                        <a class="ac-gn-link ac-gn-link-store " href="/store" data-analytics-title="store">
+                            <span class="ac-gn-link-text">Store</span>
+                        </a>
+                    </li>
+                    <li class="ac-gn-item ac-gn-item-menu ac-gn-mac">
+                        <a class="ac-gn-link ac-gn-link-mac current" href="https://www.apple.com/mac/"
+                            data-analytics-title="mac">
+                            <span class="ac-gn-link-text">Mac</span>
+                        </a>
+                    </li>
+                    <li class="ac-gn-item ac-gn-item-menu ac-gn-ipad">
+                        <a class="ac-gn-link ac-gn-link-ipad " href="https://www.apple.com/ipad/"
+                            data-analytics-title="ipad">
+                            <span class="ac-gn-link-text">iPad</span>
+                        </a>
+                    </li>
+                    <li class="ac-gn-item ac-gn-item-menu ac-gn-iphone">
+                        <a class="ac-gn-link ac-gn-link-iphone " href="https://www.apple.com/iphone/"
+                            data-analytics-title="iphone">
+                            <span class="ac-gn-link-text">iPhone</span>
+                        </a>
+                    </li>
+                    <li class="ac-gn-item ac-gn-item-menu ac-gn-watch">
+                        <a class="ac-gn-link ac-gn-link-watch " href="https://www.apple.com/watch/"
+                            data-analytics-title="watch">
+                            <span class="ac-gn-link-text">Watch</span>
+                        </a>
+                    </li>
+                    <li class="ac-gn-item ac-gn-item-menu ac-gn-airpods">
+                        <a class="ac-gn-link ac-gn-link-airpods " href="https://www.apple.com/airpods/"
+                            data-analytics-title="airpods">
+                            <span class="ac-gn-link-text">AirPods</span>
+                        </a>
+                    </li>
+                    <li class="ac-gn-item ac-gn-item-menu ac-gn-tvhome">
+                        <a class="ac-gn-link ac-gn-link-tvhome " href="https://www.apple.com/tv-home/"
+                            data-analytics-title="tv and home">
+                            <span class="ac-gn-link-text">TV &amp; Home</span>
+                        </a>
+                    </li>
+                    <li class="ac-gn-item ac-gn-item-menu ac-gn-onlyonapple">
+                        <a class="ac-gn-link ac-gn-link-onlyonapple " href="https://www.apple.com/services/"
+                            data-analytics-title="only on apple">
+                            <span class="ac-gn-link-text">Only on Apple</span>
+                        </a>
+                    </li>
+                    <li class="ac-gn-item ac-gn-item-menu ac-gn-accessories">
+                        <a class="ac-gn-link ac-gn-link-accessories current" href="/shop/accessories/all"
+                            data-analytics-title="accessories">
+                            <span class="ac-gn-link-text">Accessories</span>
+                        </a>
+                    </li>
+                    <li class="ac-gn-item ac-gn-item-menu ac-gn-support">
+                        <a class="ac-gn-link ac-gn-link-support " href="https://www.apple.com/support/"
+                            data-analytics-title="support">
+                            <span class="ac-gn-link-text">Support</span>
+                        </a>
+                    </li>
+                    <li class="ac-gn-item ac-gn-item-menu ac-gn-search" role="search">
+                        <a id="ac-gn-link-search" class="ac-gn-link ac-gn-link-search " href="/search"
+                            data-analytics-title="search" data-analytics-intrapage-link
+                            aria-label="Search apple.com"></a>
+                    </li>
+                    <li class="ac-gn-item ac-gn-bag" id="ac-gn-bag">
+                        <div class="ac-gn-bag-wrapper">
+                            <a class="ac-gn-link ac-gn-link-bag " href="/shop/bag" data-analytics-title="bag"
+                                data-analytics-click="bag" aria-label="Shopping Bag"
+                                data-string-badge="Shopping Bag with item count : {%BAGITEMCOUNT%}">
+                                <span class="ac-gn-link-text">Shopping Bag</span>
+                            </a>
+                            <span class="ac-gn-bag-badge" aria-hidden="true" data-analytics-title="bag"
+                                data-analytics-click="bag">
+                                <span class="ac-gn-bag-badge-separator"></span>
+                                <span class="ac-gn-bag-badge-number"></span>
+                                <span class="ac-gn-bag-badge-unit">+</span>
+                            </span>
+                        </div>
+                        <span class="ac-gn-bagview-caret ac-gn-bagview-caret-large"></span>
+                    </li>
+                </ul>
+                <aside id="ac-gn-searchview" class="ac-gn-searchview" role="search" data-analytics-region="search">
+                    <div class="ac-gn-searchview-content">
+                        <div class="ac-gn-searchview-bar">
+                            <div class="ac-gn-searchview-bar-wrapper">
+                                <form id="ac-gn-searchform" class="ac-gn-searchform" action="/search" method="get">
+                                    <div class="ac-gn-searchform-wrapper">
+                                        <input id="ac-gn-searchform-input" class="ac-gn-searchform-input" type="text"
+                                            aria-label="Search apple.com" placeholder="Search apple.com"
+                                            autocorrect="off" autocapitalize="off" autocomplete="off" spellcheck="false"
+                                            role="combobox" aria-autocomplete="list" aria-expanded="true"
+                                            aria-owns="quicklinks suggestions" />
+                                        <input id="ac-gn-searchform-src" type="hidden" name="src" value="globalnav" />
+                                        <button id="ac-gn-searchform-submit" class="ac-gn-searchform-submit"
+                                            type="submit" disabled aria-label="Submit Search"> </button>
+                                        <button id="ac-gn-searchform-reset" class="ac-gn-searchform-reset" type="reset"
+                                            disabled aria-label="Clear Search">
+                                            <span class="ac-gn-searchform-reset-background"></span>
+                                        </button>
+                                    </div>
+                                </form>
+                                <button id="ac-gn-searchview-close-small"
+                                    class="ac-gn-searchview-close ac-gn-searchview-close-small"
+                                    aria-label="Cancel Search">
+                                    <span class="ac-gn-searchview-close-cancel" aria-hidden="true">
+                                        Cancel
+                                    </span>
+                                </button>
+                            </div>
+                        </div>
+                        <aside id="ac-gn-searchresults" class="ac-gn-searchresults" data-string-quicklinks="Quick Links"
+                            data-string-suggestions="Suggested Searches" data-string-noresults></aside>
+                    </div>
+                    <button id="ac-gn-searchview-close" class="ac-gn-searchview-close" aria-label="Cancel Search">
+                        <span class="ac-gn-searchview-close-wrapper">
+                            <span class="ac-gn-searchview-close-left"></span>
+                            <span class="ac-gn-searchview-close-right"></span>
+                        </span>
+                    </button>
+                </aside>
+                <aside class="ac-gn-bagview" data-analytics-region="bag">
+                    <div class="ac-gn-bagview-scrim">
+                        <span class="ac-gn-bagview-caret ac-gn-bagview-caret-small"></span>
+                    </div>
+                    <div class="ac-gn-bagview-content" id="ac-gn-bagview-content">
+                    </div>
+                </aside>
+            </div>
+        </nav>
+        <div class="ac-gn-blur"></div>
+        <div id="ac-gn-curtain" class="ac-gn-curtain"></div>
+        <div id="ac-gn-placeholder" class="ac-nav-placeholder"></div>
+
+
+        <div class="localnav-wrapper gh-show-below">
+
+
+
+            <div class="localnav-expandable">
+                <nav class="localnav" role="navigation" aria-label="Local">
+                    <div class="localnav-header" data-autom="localnavHeader">
+
+                        <a href="/shop/refurbished" data-feature-name="local nav"
+                            data-display-name="Certified Refurbished" class="localnav-title">Certified Refurbished</a>
+
+                    </div>
+                    <input type="checkbox" id="localnav-disclosure" class="localnav-disclosure a11y">
+                    <div class="localnav-persistent">
+                        <label for="localnav-disclosure" class="localnav-head-disclosure" role="presentation">
+                            <span class="localnav-disclosure-button hide-outline" role="button" tabindex="0"
+                                aria-controls="localnav-tray" aria-haspopup="true" data-autom="browseAll">
+                                <span class="disclosure-text">Browse all</span>
+                                <span class="localnav-chevron" aria-hidden="true"></span>
+                            </span>
+                        </label>
+                    </div>
+                    <div id="localnav-tray" class="localnav-tray-wrapper" aria-hidden="true">
+                        <div class="localnav-tray">
+                            <div class="as-localnav-browseall as-localnav-tray-content row"
+                                id="as-localnav-tray-content">
+                                <div class="column small-12 large-12 as-localnavcolumn-nocategories">
+                                    <div class="as-localnav-browsealllistcontainer as-localnav-productlistcontainer">
+                                        <div class="as-localnav-browsealllisttitle">Shop by Refurbished Product</div>
+                                        <ul class="localnav-links as-localnav-browsealllist as-localnav-productlist">
+                                            <li class="column as-localnav-browsealllistitem">
+
+
+                                                <a href="/shop/refurbished/mac" data-feature-name="local nav"
+                                                    data-display-name="product=Mac" class="  localnav-link">Mac</a>
+                                            </li>
+                                            <li class="column as-localnav-browsealllistitem">
+
+
+                                                <a href="/shop/refurbished/ipad" data-feature-name="local nav"
+                                                    data-display-name="product=iPad" class="  localnav-link">iPad</a>
+                                            </li>
+                                            <li class="column as-localnav-browsealllistitem">
+
+
+                                                <a href="/shop/refurbished/iphone" data-feature-name="local nav"
+                                                    data-display-name="product=iPhone"
+                                                    class="  localnav-link">iPhone</a>
+                                            </li>
+                                            <li class="column as-localnav-browsealllistitem">
+
+
+                                                <a href="/shop/refurbished/watch" data-feature-name="local nav"
+                                                    data-display-name="product=Watch" class="  localnav-link">Watch</a>
+                                            </li>
+                                            <li class="column as-localnav-browsealllistitem">
+
+
+                                                <a href="/shop/refurbished/appletv" data-feature-name="local nav"
+                                                    data-display-name="product=Apple TV" class="  localnav-link">Apple
+                                                    TV</a>
+                                            </li>
+                                            <li class="column as-localnav-browsealllistitem">
+
+
+                                                <a href="/shop/refurbished/accessories" data-feature-name="local nav"
+                                                    data-display-name="product=Accessories"
+                                                    class="  localnav-link">Accessories</a>
+                                            </li>
+                                            <li class="column as-localnav-browsealllistitem">
+
+
+                                                <a href="/shop/refurbished/clearance" data-feature-name="local nav"
+                                                    data-display-name="product=Clearance"
+                                                    class="  localnav-link">Clearance</a>
+                                            </li>
+                                            <li class="column as-localnav-browsealllistitem">
+
+
+                                                <a href="/shop/refurbished/about" data-feature-name="local nav"
+                                                    data-display-name="product=Why Refurbished"
+                                                    class="  localnav-link">Why Refurbished</a>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                </nav>
+            </div>
+
+        </div>
+        <div class="as-localnav-placeholder"></div>
+        <div class="as-localnav-curtain"></div>
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                new as.LocalNav('body', {
+                    stickyClass: 'is-sticking',
+                    maxElement: '#ac-globalnav',
+                    exploreElement: '#localnav-disclosure'
+
+
+                });
+            });
+        </script>
+
+
+        <div role="main">
+            <div id="notification-portal"></div>
+            <div class="as-l-fullwidth  as-navtuck" data-events="event52">
+
+                <div>
+                    <div class="dd-refurb-category-header">
+                        <div class="dd-fill-background">
+                            <div class="dd-l-plate">
+                                <div class="row">
+                                    <div class="column large-5 small-12">
+                                        <div class="dd-info">
+                                            <h2 class="t-headline-reduced">
+                                                Refurbished Mac
+                                            </h2>
+                                            <p class="dd-subcopy">
+                                                Discover what goes into each refurbished Mac.
+                                            </p>
+                                            <p class="dd-link">
+                                                <a href="/shop/browse/overlay/refurbished/mac" data-slot-name="main1"
+                                                    data-feature-name="Astro Link"
+                                                    data-display-name="AOS: overlay/refurbished/mac"
+                                                    data-ase-loader="buyflow-info-overlay-loader"
+                                                    data-ase-loader-action="load" class="more">Learn more<span
+                                                        class="visuallyhidden"> about each refurbished Mac.</span></a>
+                                            </p>
+                                        </div>
+                                    </div>
+                                    <div class="column large-7 small-12">
+                                        <div class="dd-background">
+                                            <img src="https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/mac-refurb-category-201810?wid=2006&amp;hei=640&amp;fmt=jpeg&amp;qlt=90&amp;.v=1541530955030"
+                                                alt="" width="1003" height="320"
+                                                data-scale-params-1="wid=1003&amp;hei=320&amp;fmt=jpeg&amp;qlt=95&amp;.v=1541530955030"
+                                                data-scale-initial="2" class="dd-hero ir" />
+
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="dd-mow-content dd-fill">
+                            <div class="dd-l-plate">
+                                <div class="dd-mow-info">
+                                    <p class="t-body-reduced" aria-hidden="true">
+                                        Discover what goes into each refurbished Mac. <a
+                                            href="/shop/browse/overlay/refurbished/mac" data-slot-name="main1"
+                                            data-feature-name="Astro Link"
+                                            data-display-name="AOS: overlay/refurbished/mac"
+                                            data-ase-loader="buyflow-info-overlay-loader" data-ase-loader-action="load"
+                                            class="more" aria-label="Learn more about each refurbished Mac">Learn
+                                            more<span class="visuallyhidden"> about each refurbished Mac.</span></a>
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+
+
+
+
+
+
+
+
+
+            </div>
+
+            <div id="root"></div>
+
+
+
+
+            <script>
+                window.REFURB_GRID_BOOTSTRAP = { "products": [{ "dimensions": { "dimensionCapacity": "4tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "32gb" } }, { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "1_5tb" } }, { "dimensions": { "dimensionCapacity": "512gb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "32gb" } }, { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "14inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2021", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, { "dimensions": { "dimensionCapacity": "2tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "32gb" } }, { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2020", "dimensionColor": "space_gray", "tsMemorySize": "8gb" } }, { "dimensions": { "dimensionCapacity": "512gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "16inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2021", "dimensionColor": "silver", "tsMemorySize": "32gb" } }, { "dimensions": { "dimensionCapacity": "256gb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "96gb" } }, { "dimensions": { "dimensionCapacity": "4tb", "refurbClearModel": "macpro", "dimensionRelYear": "2019" } }, { "dimensions": { "dimensionCapacity": "512gb", "dimensionScreensize": "16inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2021", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "32gb" } }, { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, { "dimensions": { "dimensionCapacity": "512gb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, { "dimensions": { "dimensionCapacity": "2tb", "dimensionScreensize": "14inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2021", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, { "dimensions": { "dimensionCapacity": "512gb", "refurbClearModel": "macstudio", "dimensionRelYear": "2022" } }, { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macmini", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, { "dimensions": { "dimensionCapacity": "2tb", "dimensionScreensize": "27inch", "refurbClearModel": "imac", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "128gb" } }, { "dimensions": { "dimensionCapacity": "256gb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "48gb" } }, { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookair", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "96gb" } }, { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookair", "dimensionRelYear": "2020", "dimensionColor": "space_gray", "tsMemorySize": "8gb" } }, { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookair", "dimensionRelYear": "2020", "dimensionColor": "gold", "tsMemorySize": "16gb" } }, { "dimensions": { "dimensionCapacity": "8tb", "dimensionScreensize": "27inch", "refurbClearModel": "imac", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "128gb" } }, { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "128gb" } }, { "dimensions": { "dimensionCapacity": "256gb", "refurbClearModel": "macmini", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "32gb" } }, { "dimensions": { "dimensionCapacity": "8tb", "dimensionScreensize": "27inch", "refurbClearModel": "imac", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, { "dimensions": { "dimensionCapacity": "2tb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "48gb" } }, { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2017", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookair", "dimensionRelYear": "2020", "dimensionColor": "gold", "tsMemorySize": "8gb" } }, { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "14inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2021", "dimensionColor": "space_gray", "tsMemorySize": "16gb" } }, { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "32gb" } }, { "dimensions": { "dimensionCapacity": "512gb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, { "dimensions": { "dimensionCapacity": "4tb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "1_5tb" } }, { "dimensions": { "dimensionCapacity": "8tb", "dimensionScreensize": "27inch", "refurbClearModel": "imac", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, { "dimensions": { "dimensionCapacity": "256gb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "1_5tb" } }, { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, { "dimensions": { "dimensionCapacity": "512gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookair", "dimensionRelYear": "2020", "dimensionColor": "space_gray", "tsMemorySize": "16gb" } }, { "dimensions": { "dimensionCapacity": "128gb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, { "dimensions": { "dimensionCapacity": "512gb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "8gb" } }, { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macstudio", "dimensionRelYear": "2022" } }, { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2017", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "16inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2021", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, { "dimensions": { "dimensionCapacity": "512gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookair", "dimensionRelYear": "2020", "dimensionColor": "space_gray", "tsMemorySize": "8gb" } }, { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macmini", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, { "dimensions": { "dimensionCapacity": "512gb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "16gb" } }, { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookair", "dimensionRelYear": "2020", "dimensionColor": "space_gray", "tsMemorySize": "16gb" } }, { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "27inch", "refurbClearModel": "imac", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "128gb" } }, { "dimensions": { "dimensionCapacity": "2tb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "14inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2021", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, { "dimensions": { "dimensionCapacity": "2tb", "refurbClearModel": "macmini", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, { "dimensions": { "dimensionCapacity": "2tb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "8gb" } }, { "dimensions": { "refurbClearModel": "macstudio", "dimensionRelYear": "2022" } }, { "dimensions": { "dimensionCapacity": "4tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, { "dimensions": { "dimensionCapacity": "256gb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "8gb" } }, { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "27inch", "refurbClearModel": "imac", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "128gb" } }, { "dimensions": { "dimensionCapacity": "4tb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "192gb" } }, { "dimensions": { "dimensionCapacity": "512gb", "refurbClearModel": "macmini", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, { "dimensions": { "dimensionCapacity": "4tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "128gb" } }, { "dimensions": { "dimensionCapacity": "2tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "128gb" } }, { "dimensions": { "dimensionCapacity": "512gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookair", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2020", "dimensionColor": "space_gray", "tsMemorySize": "16gb" } }, { "dimensions": { "dimensionCapacity": "512gb", "dimensionScreensize": "16inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2021", "dimensionColor": "space_gray", "tsMemorySize": "16gb" } }, { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "48gb" } }, { "dimensions": { "dimensionCapacity": "512gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookair", "dimensionRelYear": "2020", "dimensionColor": "gold", "tsMemorySize": "8gb" } }, { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2017", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, { "dimensions": { "dimensionCapacity": "512gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2020", "dimensionColor": "space_gray", "tsMemorySize": "8gb" } }, { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "16gb" } }, { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "27inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, { "dimensions": { "dimensionCapacity": "2tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "16gb" } }], "dictionaries": { "dimensions": { "dimensionCapacity": { "512gb": { "sortOrder": 2, "text": "512GB" }, "2tb": { "sortOrder": 5, "text": "2TB" }, "3tb": { "sortOrder": 6, "text": "3TB" }, "4tb": { "sortOrder": 7, "text": "4TB" }, "1point5tb": { "sortOrder": 4, "text": "1.5 TB" }, "8tb": { "sortOrder": 8, "text": "8 TB" }, "256gb": { "sortOrder": 1, "text": "256GB" }, "128gb": { "sortOrder": 0, "text": "128GB" }, "1tb": { "sortOrder": 3, "text": "1TB" } }, "dimensionScreensize": { "13inch": { "sortOrder": 0, "text": "13-inch" }, "27inch": { "sortOrder": 5, "text": "27-inch" }, "14inch": { "sortOrder": 1, "text": "14-inch" }, "16inch": { "sortOrder": 2, "text": "16-inch" }, "21_5inch": { "sortOrder": 3, "text": "21.5-inch" }, "24inch": { "sortOrder": 4, "text": "24-inch" } }, "refurbClearModel": { "macbookair": { "sortOrder": 0, "text": "MacBook Air" }, "macstudio": { "sortOrder": 4, "text": "Mac Studio" }, "imacpro2017": { "sortOrder": 5, "text": "iMac Pro" }, "macmini": { "sortOrder": 3, "text": "Mac mini" }, "macbookpro": { "sortOrder": 1, "text": "MacBook Pro" }, "imac": { "sortOrder": 2, "text": "iMac" }, "macpro": { "sortOrder": 6, "text": "Mac Pro" }, "macaccessories": { "sortOrder": 7, "text": "Mac Accessories" } }, "dimensionRelYear": { "2019": { "sortOrder": 2, "text": "2019" }, "2018": { "sortOrder": 1, "text": "2018" }, "2017": { "sortOrder": 0, "text": "2017" }, "2022": { "sortOrder": 5, "text": "2022" }, "2021": { "sortOrder": 4, "text": "2021" }, "2020": { "sortOrder": 3, "text": "2020" } }, "dimensionColor": { "orange": { "sortOrder": 4, "text": "Orange" }, "gold": { "sortOrder": 8, "text": "Gold" }, "space_gray": { "sortOrder": 1, "text": "Space Gray" }, "pink": { "sortOrder": 5, "text": "Pink" }, "green": { "sortOrder": 2, "text": "Green" }, "blue": { "sortOrder": 7, "text": "Blue" }, "yellow": { "sortOrder": 3, "text": "Yellow" }, "purple": { "sortOrder": 6, "text": "Purple" }, "silver": { "sortOrder": 0, "text": "Silver" } }, "tsMemorySize": { "64gb": { "sortOrder": 4, "text": "64GB" }, "96gb": { "sortOrder": 5, "text": "96GB" }, "8gb": { "sortOrder": 0, "text": "8GB" }, "768gb": { "sortOrder": 8, "text": "768GB" }, "16gb": { "sortOrder": 1, "text": "16GB" }, "48gb": { "sortOrder": 3, "text": "48GB" }, "128gb": { "sortOrder": 6, "text": "128GB" }, "192gb": { "sortOrder": 7, "text": "192GB" }, "1_5tb": { "sortOrder": 9, "text": "1.5TB" }, "32gb": { "sortOrder": 2, "text": "32GB" } } } }, "tiles": [{ "partNumber": "FGNR3LL/A", "sortOrder": 0, "filters": { "dimensions": { "dimensionCapacity": "256gb", "refurbClearModel": "macmini", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "previousPrice": { "amount": null, "raw_amount": "589.00", "previousPrice": "<span class = \"was-text\">Was</span> $699.00" }, "savings": "Save $110.00", "priceCurrency": "USD", "partNumber": "FGNR3LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "FGNR3", "originalProductAmount": 699.00, "currentPrice": { "amount": "$589.00", "raw_amount": "589.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini Apple M1 Chip with 8‑Core CPU and 8‑Core GPU", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2020?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1614364640000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1614364640000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2020", "originalImageName": "refurb-mac-mini-2020", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/FGNR3LL/A/refurbished-mac-mini-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 138, "priceAsc": 0 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "FGNR3LL/A", "basePartNumber": "FGNR3", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "FXNF2LL/A", "sortOrder": 1, "filters": { "dimensions": { "dimensionCapacity": "256gb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "previousPrice": { "amount": null, "raw_amount": "679.00", "previousPrice": "<span class = \"was-text\">Was</span> $799.00" }, "savings": "Save $120.00", "priceCurrency": "USD", "partNumber": "FXNF2LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "FXNF2", "originalProductAmount": 799.00, "currentPrice": { "amount": "$679.00", "raw_amount": "679.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini 3.6GHz quad-core Intel Core i3 - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1553797551145", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1553797551145" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2018", "originalImageName": "refurb-mac-mini-2018", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/FXNF2LL/A/Refurbished-Mac-mini-36GHz-quad-core-Intel-Core-i3-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 137, "priceAsc": 1 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "FXNF2LL/A", "basePartNumber": "FXNF2", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "FGNT3LL/A", "sortOrder": 2, "filters": { "dimensions": { "dimensionCapacity": "512gb", "refurbClearModel": "macmini", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "previousPrice": { "amount": null, "raw_amount": "759.00", "previousPrice": "<span class = \"was-text\">Was</span> $899.00" }, "savings": "Save $140.00", "priceCurrency": "USD", "partNumber": "FGNT3LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "FGNT3", "originalProductAmount": 899.00, "currentPrice": { "amount": "$759.00", "raw_amount": "759.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini Apple M1 Chip with 8‑Core CPU and 8‑Core GPU", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2020?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1614364640000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1614364640000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2020", "originalImageName": "refurb-mac-mini-2020", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/FGNT3LL/A/refurbished-mac-mini-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 136, "priceAsc": 2 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "FGNT3LL/A", "basePartNumber": "FGNT3", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "FGND3LL/A", "sortOrder": 3, "filters": { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookair", "dimensionRelYear": "2020", "dimensionColor": "gold", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "previousPrice": { "amount": null, "raw_amount": "849.00", "previousPrice": "<span class = \"was-text\">Was</span> $999.00" }, "savings": "Save $150.00", "priceCurrency": "USD", "partNumber": "FGND3LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "FGND3", "originalProductAmount": 999.00, "currentPrice": { "amount": "$849.00", "raw_amount": "849.00" }, "adjustedPrice": {} }, "title": "Refurbished 13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 7‑Core GPU - Gold", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-macbook-air-gold-m1-202010?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1634145607000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1634145607000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-macbook-air-gold-m1-202010", "originalImageName": "refurb-macbook-air-gold-m1-202010", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/FGND3LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8%E2%80%91core-cpu-and-7%E2%80%91core-gpu-gold?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 135, "priceAsc": 3 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "FGND3LL/A", "basePartNumber": "FGND3", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "FGN93LL/A", "sortOrder": 4, "filters": { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookair", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "previousPrice": { "amount": null, "raw_amount": "849.00", "previousPrice": "<span class = \"was-text\">Was</span> $999.00" }, "savings": "Save $150.00", "priceCurrency": "USD", "partNumber": "FGN93LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "FGN93", "originalProductAmount": 999.00, "currentPrice": { "amount": "$849.00", "raw_amount": "849.00" }, "adjustedPrice": {} }, "title": "Refurbished 13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 7‑Core GPU - Silver", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-macbook-air-silver-m1-202010?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1634145618000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1634145618000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-macbook-air-silver-m1-202010", "originalImageName": "refurb-macbook-air-silver-m1-202010", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/FGN93LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8%E2%80%91core-cpu-and-7%E2%80%91core-gpu-silver?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 134, "priceAsc": 4 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "FGN93LL/A", "basePartNumber": "FGN93", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "FGN63LL/A", "sortOrder": 5, "filters": { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookair", "dimensionRelYear": "2020", "dimensionColor": "space_gray", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "previousPrice": { "amount": null, "raw_amount": "849.00", "previousPrice": "<span class = \"was-text\">Was</span> $999.00" }, "savings": "Save $150.00", "priceCurrency": "USD", "partNumber": "FGN63LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "FGN63", "originalProductAmount": 999.00, "currentPrice": { "amount": "$849.00", "raw_amount": "849.00" }, "adjustedPrice": {} }, "title": "Refurbished 13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 7‑Core GPU - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-macbook-air-space-gray-m1-202010?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1634145627000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1634145627000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-macbook-air-space-gray-m1-202010", "originalImageName": "refurb-macbook-air-space-gray-m1-202010", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/FGN63LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8%E2%80%91core-cpu-and-7%E2%80%91core-gpu-space-gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 133, "priceAsc": 5 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "FGN63LL/A", "basePartNumber": "FGN63", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "FRT32LL/A", "sortOrder": 6, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "previousPrice": { "amount": null, "raw_amount": "899.00", "previousPrice": "<span class = \"was-text\">Was</span> $1,249.00" }, "savings": "Save $350.00", "priceCurrency": "USD", "partNumber": "FRT32LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "FRT32", "originalProductAmount": 1249.00, "currentPrice": { "amount": "$899.00", "raw_amount": "899.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 3.6GHz quad-core Intel Core i3 with Retina 4K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087778", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087778" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-215-gallery", "originalImageName": "refurb-2019-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/FRT32LL/A/Refurbished-215-inch-iMac-36GHz-quad-core-Intel-Core-i3-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 132, "priceAsc": 6 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "FRT32LL/A", "basePartNumber": "FRT32", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0TH0LL/A", "sortOrder": 7, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2017", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0TH0LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0TH0", "currentPrice": { "amount": "$929.00", "raw_amount": "929.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 2.3GHz dual-core Intel Core i5", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2017-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1499114976977", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1499114976977" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2017-imac-215-gallery", "originalImageName": "refurb-2017-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0TH0LL/A/Refurbished-215-inch-iMac-23GHz-dual-core-Intel-Core-i5?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 131, "priceAsc": 7 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0TH0LL/A", "basePartNumber": "G0TH0", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G12P1LL/A", "sortOrder": 8, "filters": { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macmini", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G12P1LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G12P1", "currentPrice": { "amount": "$929.00", "raw_amount": "929.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini Apple M1 Chip with 8‑Core CPU and 8‑Core GPU", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2020?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1614364640000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1614364640000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2020", "originalImageName": "refurb-mac-mini-2020", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G12P1LL/A/refurbished-mac-mini-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 130, "priceAsc": 8 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G12P1LL/A", "basePartNumber": "G12P1", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0TH1LL/A", "sortOrder": 9, "filters": { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2017", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0TH1LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0TH1", "currentPrice": { "amount": "$929.00", "raw_amount": "929.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 2.3GHz dual-core Intel Core i5", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2017-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1499114976977", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1499114976977" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2017-imac-215-gallery", "originalImageName": "refurb-2017-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0TH1LL/A/Refurbished-215-inch-iMac-23GHz-dual-core-Intel-Core-i5?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 129, "priceAsc": 9 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0TH1LL/A", "basePartNumber": "G0TH1", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "FXNG2LL/A", "sortOrder": 10, "filters": { "dimensions": { "dimensionCapacity": "512gb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "previousPrice": { "amount": null, "raw_amount": "929.00", "previousPrice": "<span class = \"was-text\">Was</span> $1,099.00" }, "savings": "Save $170.00", "priceCurrency": "USD", "partNumber": "FXNG2LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "FXNG2", "originalProductAmount": 1099.00, "currentPrice": { "amount": "$929.00", "raw_amount": "929.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini 3.0GHz 6-core Intel Core i5 - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1553797551145", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1553797551145" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2018", "originalImageName": "refurb-mac-mini-2018", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/FXNG2LL/A/Refurbished-Mac-mini-30GHz-6-core-Intel-Core-i5-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 128, "priceAsc": 10 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "FXNG2LL/A", "basePartNumber": "FXNG2", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "FYD82LL/A", "sortOrder": 11, "filters": { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2020", "dimensionColor": "space_gray", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "previousPrice": { "amount": null, "raw_amount": "1059.00", "previousPrice": "<span class = \"was-text\">Was</span> $1,249.00" }, "savings": "Save $190.00", "priceCurrency": "USD", "partNumber": "FYD82LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "FYD82", "originalProductAmount": 1249.00, "currentPrice": { "amount": "$1,059.00", "raw_amount": "1059.00" }, "adjustedPrice": {} }, "title": "Refurbished 13.3-inch MacBook Pro Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp13-space-m1-2020?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1628621779000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1628621779000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mbp13-space-m1-2020", "originalImageName": "refurb-mbp13-space-m1-2020", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/FYD82LL/A/refurbished-133-inch-macbook-pro-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu-space-gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 127, "priceAsc": 11 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "FYD82LL/A", "basePartNumber": "FYD82", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "FGNA3LL/A", "sortOrder": 12, "filters": { "dimensions": { "dimensionCapacity": "512gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookair", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "previousPrice": { "amount": null, "raw_amount": "1059.00", "previousPrice": "<span class = \"was-text\">Was</span> $1,149.00" }, "savings": "Save $90.00", "priceCurrency": "USD", "partNumber": "FGNA3LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "FGNA3", "originalProductAmount": 1149.00, "currentPrice": { "amount": "$1,059.00", "raw_amount": "1059.00" }, "adjustedPrice": {} }, "title": "Refurbished 13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Silver", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-macbook-air-silver-m1-202010?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1634145618000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1634145618000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-macbook-air-silver-m1-202010", "originalImageName": "refurb-macbook-air-silver-m1-202010", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/FGNA3LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu-silver?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 126, "priceAsc": 12 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "FGNA3LL/A", "basePartNumber": "FGNA3", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "FGN73LL/A", "sortOrder": 13, "filters": { "dimensions": { "dimensionCapacity": "512gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookair", "dimensionRelYear": "2020", "dimensionColor": "space_gray", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "previousPrice": { "amount": null, "raw_amount": "1059.00", "previousPrice": "<span class = \"was-text\">Was</span> $1,149.00" }, "savings": "Save $90.00", "priceCurrency": "USD", "partNumber": "FGN73LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "FGN73", "originalProductAmount": 1149.00, "currentPrice": { "amount": "$1,059.00", "raw_amount": "1059.00" }, "adjustedPrice": {} }, "title": "Refurbished 13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-macbook-air-space-gray-m1-202010?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1634145627000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1634145627000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-macbook-air-space-gray-m1-202010", "originalImageName": "refurb-macbook-air-space-gray-m1-202010", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/FGN73LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu-space-gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 125, "priceAsc": 13 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "FGN73LL/A", "basePartNumber": "FGN73", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0TH3LL/A", "sortOrder": 14, "filters": { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2017", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0TH3LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0TH3", "currentPrice": { "amount": "$1,059.00", "raw_amount": "1059.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 2.3GHz dual-core Intel Core i5", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2017-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1499114976977", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1499114976977" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2017-imac-215-gallery", "originalImageName": "refurb-2017-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0TH3LL/A/refurbished-215-inch-imac-23ghz-dual-core-intel-core-i5?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 124, "priceAsc": 14 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0TH3LL/A", "basePartNumber": "G0TH3", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "FYDA2LL/A", "sortOrder": 15, "filters": { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "previousPrice": { "amount": null, "raw_amount": "1059.00", "previousPrice": "<span class = \"was-text\">Was</span> $1,249.00" }, "savings": "Save $190.00", "priceCurrency": "USD", "partNumber": "FYDA2LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "FYDA2", "originalProductAmount": 1249.00, "currentPrice": { "amount": "$1,059.00", "raw_amount": "1059.00" }, "adjustedPrice": {} }, "title": "Refurbished 13.3-inch MacBook Pro Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Silver", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp13-silver-m1-2020?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1628621726000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1628621726000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mbp13-silver-m1-2020", "originalImageName": "refurb-mbp13-silver-m1-2020", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/FYDA2LL/A/refurbished-133-inch-macbook-pro-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu-silver?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 123, "priceAsc": 15 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "FYDA2LL/A", "basePartNumber": "FYDA2", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "FGNE3LL/A", "sortOrder": 16, "filters": { "dimensions": { "dimensionCapacity": "512gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookair", "dimensionRelYear": "2020", "dimensionColor": "gold", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "previousPrice": { "amount": null, "raw_amount": "1059.00", "previousPrice": "<span class = \"was-text\">Was</span> $1,149.00" }, "savings": "Save $90.00", "priceCurrency": "USD", "partNumber": "FGNE3LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "FGNE3", "originalProductAmount": 1149.00, "currentPrice": { "amount": "$1,059.00", "raw_amount": "1059.00" }, "adjustedPrice": {} }, "title": "Refurbished 13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Gold", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-macbook-air-gold-m1-202010?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1634145607000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1634145607000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-macbook-air-gold-m1-202010", "originalImageName": "refurb-macbook-air-gold-m1-202010", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/FGNE3LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu-gold?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 122, "priceAsc": 16 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "FGNE3LL/A", "basePartNumber": "FGNE3", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G12P7LL/A", "sortOrder": 17, "filters": { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macmini", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G12P7LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G12P7", "currentPrice": { "amount": "$1,099.00", "raw_amount": "1099.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini Apple M1 Chip with 8‑Core CPU and 8‑Core GPU", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2020?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1614364640000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1614364640000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2020", "originalImageName": "refurb-mac-mini-2020", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G12P7LL/A/refurbished-mac-mini-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 121, "priceAsc": 17 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G12P7LL/A", "basePartNumber": "G12P7", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0TH2LL/A", "sortOrder": 18, "filters": { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2017", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0TH2LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0TH2", "currentPrice": { "amount": "$1,099.00", "raw_amount": "1099.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 2.3GHz dual-core Intel Core i5", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2017-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1499114976977", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1499114976977" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2017-imac-215-gallery", "originalImageName": "refurb-2017-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0TH2LL/A/Refurbished-215-inch-iMac-23GHz-dual-core-Intel-Core-i5?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 120, "priceAsc": 18 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0TH2LL/A", "basePartNumber": "G0TH2", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0ZTPLL/A", "sortOrder": 19, "filters": { "dimensions": { "dimensionCapacity": "512gb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0ZTPLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0ZTP", "currentPrice": { "amount": "$1,099.00", "raw_amount": "1099.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1553797551145", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1553797551145" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2018", "originalImageName": "refurb-mac-mini-2018", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0ZTPLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 119, "priceAsc": 19 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0ZTPLL/A", "basePartNumber": "G0ZTP", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0ZT5LL/A", "sortOrder": 20, "filters": { "dimensions": { "dimensionCapacity": "512gb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0ZT5LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0ZT5", "currentPrice": { "amount": "$1,099.00", "raw_amount": "1099.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini 3.0GHz 6-core Intel Core i5 - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1553797551145", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1553797551145" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2018", "originalImageName": "refurb-mac-mini-2018", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0ZT5LL/A/Refurbished-Mac-mini-30GHz-6-core-Intel-Core-i5-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 118, "priceAsc": 20 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0ZT5LL/A", "basePartNumber": "G0ZT5", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0TH4LL/A", "sortOrder": 21, "filters": { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2017", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0TH4LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0TH4", "currentPrice": { "amount": "$1,099.00", "raw_amount": "1099.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 2.3GHz dual-core Intel Core i5", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2017-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1499114976977", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1499114976977" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2017-imac-215-gallery", "originalImageName": "refurb-2017-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0TH4LL/A/Refurbished-215-inch-iMac-23GHz-dual-core-Intel-Core-i5?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 117, "priceAsc": 21 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0TH4LL/A", "basePartNumber": "G0TH4", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0VX1LL/A", "sortOrder": 22, "filters": { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0VX1LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0VX1", "currentPrice": { "amount": "$1,099.00", "raw_amount": "1099.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 3.6GHz quad-core Intel Core i3 with Retina 4K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087778", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087778" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-215-gallery", "originalImageName": "refurb-2019-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0VX1LL/A/Refurbished-215-inch-iMac-36GHz-quad-core-Intel-Core-i3-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 116, "priceAsc": 22 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0VX1LL/A", "basePartNumber": "G0VX1", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G12P8LL/A", "sortOrder": 23, "filters": { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macmini", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G12P8LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G12P8", "currentPrice": { "amount": "$1,189.00", "raw_amount": "1189.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini Apple M1 Chip with 8‑Core CPU and 8‑Core GPU, 10GB Ethernet", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2020?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1614364640000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1614364640000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2020", "originalImageName": "refurb-mac-mini-2020", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G12P8LL/A/Refurbished-Mac-mini-Apple-M1-Chip-with-8%E2%80%91Core-CPU-and-8%E2%80%91Core-GPU-10GB-Ethernet?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 115, "priceAsc": 23 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G12P8LL/A", "basePartNumber": "G12P8", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "FYDC2LL/A", "sortOrder": 24, "filters": { "dimensions": { "dimensionCapacity": "512gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "previousPrice": { "amount": null, "raw_amount": "1229.00", "previousPrice": "<span class = \"was-text\">Was</span> $1,449.00" }, "savings": "Save $220.00", "priceCurrency": "USD", "partNumber": "FYDC2LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "FYDC2", "originalProductAmount": 1449.00, "currentPrice": { "amount": "$1,229.00", "raw_amount": "1229.00" }, "adjustedPrice": {} }, "title": "Refurbished 13.3-inch MacBook Pro Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Silver", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp13-silver-m1-2020?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1628621726000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1628621726000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mbp13-silver-m1-2020", "originalImageName": "refurb-mbp13-silver-m1-2020", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/FYDC2LL/A/refurbished-133-inch-macbook-pro-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu-silver?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 114, "priceAsc": 24 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "FYDC2LL/A", "basePartNumber": "FYDC2", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G1252LL/A", "sortOrder": 25, "filters": { "dimensions": { "dimensionCapacity": "512gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookair", "dimensionRelYear": "2020", "dimensionColor": "space_gray", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G1252LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G1252", "currentPrice": { "amount": "$1,229.00", "raw_amount": "1229.00" }, "adjustedPrice": {} }, "title": "Refurbished 13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-macbook-air-space-gray-m1-202010?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1634145627000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1634145627000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-macbook-air-space-gray-m1-202010", "originalImageName": "refurb-macbook-air-space-gray-m1-202010", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G1252LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu-space-gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 113, "priceAsc": 25 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G1252LL/A", "basePartNumber": "G1252", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "FYD92LL/A", "sortOrder": 26, "filters": { "dimensions": { "dimensionCapacity": "512gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2020", "dimensionColor": "space_gray", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "previousPrice": { "amount": null, "raw_amount": "1229.00", "previousPrice": "<span class = \"was-text\">Was</span> $1,449.00" }, "savings": "Save $220.00", "priceCurrency": "USD", "partNumber": "FYD92LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "FYD92", "originalProductAmount": 1449.00, "currentPrice": { "amount": "$1,229.00", "raw_amount": "1229.00" }, "adjustedPrice": {} }, "title": "Refurbished 13.3-inch MacBook Pro Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp13-space-m1-2020?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1628621779000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1628621779000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mbp13-space-m1-2020", "originalImageName": "refurb-mbp13-space-m1-2020", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/FYD92LL/A/refurbished-133-inch-macbook-pro-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu-space-gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 112, "priceAsc": 26 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "FYD92LL/A", "basePartNumber": "FYD92", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G11B0LL/A", "sortOrder": 27, "filters": { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2020", "dimensionColor": "space_gray", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G11B0LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G11B0", "currentPrice": { "amount": "$1,229.00", "raw_amount": "1229.00" }, "adjustedPrice": {} }, "title": "Refurbished 13.3-inch MacBook Pro Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp13-space-m1-2020?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1628621779000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1628621779000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mbp13-space-m1-2020", "originalImageName": "refurb-mbp13-space-m1-2020", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G11B0LL/A/refurbished-133-inch-macbook-pro-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu-space-gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 111, "priceAsc": 27 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G11B0LL/A", "basePartNumber": "G11B0", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0VX6LL/A", "sortOrder": 28, "filters": { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0VX6LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0VX6", "currentPrice": { "amount": "$1,269.00", "raw_amount": "1269.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 3.6GHz quad-core Intel Core i3 with Retina 4K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087778", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087778" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-215-gallery", "originalImageName": "refurb-2019-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0VX6LL/A/Refurbished-215-inch-iMac-36GHz-quad-core-Intel-Core-i3-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 110, "priceAsc": 28 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0VX6LL/A", "basePartNumber": "G0VX6", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0ZT7LL/A", "sortOrder": 29, "filters": { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0ZT7LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0ZT7", "currentPrice": { "amount": "$1,269.00", "raw_amount": "1269.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini 3.0GHz 6-core Intel Core i5 - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1553797551145", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1553797551145" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2018", "originalImageName": "refurb-mac-mini-2018", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0ZT7LL/A/Refurbished-Mac-mini-30GHz-6-core-Intel-Core-i5-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 109, "priceAsc": 29 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0ZT7LL/A", "basePartNumber": "G0ZT7", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0VY1LL/A", "sortOrder": 30, "filters": { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0VY1LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0VY1", "currentPrice": { "amount": "$1,269.00", "raw_amount": "1269.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087778", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087778" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-215-gallery", "originalImageName": "refurb-2019-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0VY1LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 108, "priceAsc": 30 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0VY1LL/A", "basePartNumber": "G0VY1", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G1253LL/A", "sortOrder": 31, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookair", "dimensionRelYear": "2020", "dimensionColor": "space_gray", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G1253LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G1253", "currentPrice": { "amount": "$1,399.00", "raw_amount": "1399.00" }, "adjustedPrice": {} }, "title": "Refurbished 13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-macbook-air-space-gray-m1-202010?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1634145627000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1634145627000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-macbook-air-space-gray-m1-202010", "originalImageName": "refurb-macbook-air-space-gray-m1-202010", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G1253LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu-space-gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 107, "priceAsc": 31 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G1253LL/A", "basePartNumber": "G1253", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G12B3LL/A", "sortOrder": 32, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "13inch", "refurbClearModel": "macbookair", "dimensionRelYear": "2020", "dimensionColor": "gold", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G12B3LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G12B3", "currentPrice": { "amount": "$1,399.00", "raw_amount": "1399.00" }, "adjustedPrice": {} }, "title": "Refurbished 13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Gold", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-macbook-air-gold-m1-202010?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1634145607000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1634145607000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-macbook-air-gold-m1-202010", "originalImageName": "refurb-macbook-air-gold-m1-202010", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G12B3LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu-gold?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 106, "priceAsc": 32 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G12B3LL/A", "basePartNumber": "G12B3", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0W18LL/A", "sortOrder": 33, "filters": { "dimensions": { "dimensionCapacity": "128gb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0W18LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0W18", "currentPrice": { "amount": "$1,439.00", "raw_amount": "1439.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini 3.6GHz quad-core Intel Core i3 - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1553797551145", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1553797551145" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2018", "originalImageName": "refurb-mac-mini-2018", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0W18LL/A/Refurbished-Mac-mini-36GHz-quad-core-Intel-Core-i3-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 105, "priceAsc": 33 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0W18LL/A", "basePartNumber": "G0W18", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0W2ULL/A", "sortOrder": 34, "filters": { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0W2ULL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0W2U", "currentPrice": { "amount": "$1,439.00", "raw_amount": "1439.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1553797551145", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1553797551145" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2018", "originalImageName": "refurb-mac-mini-2018", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0W2ULL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 104, "priceAsc": 34 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0W2ULL/A", "basePartNumber": "G0W2U", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0VX3LL/A", "sortOrder": 35, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0VX3LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0VX3", "currentPrice": { "amount": "$1,439.00", "raw_amount": "1439.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 3.6GHz quad-core Intel Core i3 with Retina 4K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087778", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087778" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-215-gallery", "originalImageName": "refurb-2019-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0VX3LL/A/Refurbished-215-inch-iMac-36GHz-quad-core-Intel-Core-i3-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 103, "priceAsc": 35 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0VX3LL/A", "basePartNumber": "G0VX3", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0ZTXLL/A", "sortOrder": 36, "filters": { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0ZTXLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0ZTX", "currentPrice": { "amount": "$1,439.00", "raw_amount": "1439.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1553797551145", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1553797551145" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2018", "originalImageName": "refurb-mac-mini-2018", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0ZTXLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 102, "priceAsc": 36 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0ZTXLL/A", "basePartNumber": "G0ZTX", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0VYRLL/A", "sortOrder": 37, "filters": { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0VYRLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0VYR", "currentPrice": { "amount": "$1,439.00", "raw_amount": "1439.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087778", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087778" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-215-gallery", "originalImageName": "refurb-2019-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0VYRLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 101, "priceAsc": 37 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0VYRLL/A", "basePartNumber": "G0VYR", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0VY9LL/A", "sortOrder": 38, "filters": { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0VY9LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0VY9", "currentPrice": { "amount": "$1,439.00", "raw_amount": "1439.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087778", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087778" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-215-gallery", "originalImageName": "refurb-2019-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0VY9LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 100, "priceAsc": 38 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0VY9LL/A", "basePartNumber": "G0VY9", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G12P9LL/A", "sortOrder": 39, "filters": { "dimensions": { "dimensionCapacity": "2tb", "refurbClearModel": "macmini", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G12P9LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G12P9", "currentPrice": { "amount": "$1,439.00", "raw_amount": "1439.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini Apple M1 Chip with 8‑Core CPU and 8‑Core GPU", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2020?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1614364640000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1614364640000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2020", "originalImageName": "refurb-mac-mini-2020", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G12P9LL/A/refurbished-mac-mini-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 99, "priceAsc": 39 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G12P9LL/A", "basePartNumber": "G12P9", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0VY3LL/A", "sortOrder": 40, "filters": { "dimensions": { "dimensionCapacity": "512gb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0VY3LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0VY3", "currentPrice": { "amount": "$1,439.00", "raw_amount": "1439.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087778", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087778" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-215-gallery", "originalImageName": "refurb-2019-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0VY3LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 98, "priceAsc": 40 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0VY3LL/A", "basePartNumber": "G0VY3", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G12PALL/A", "sortOrder": 41, "filters": { "dimensions": { "dimensionCapacity": "2tb", "refurbClearModel": "macmini", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G12PALL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G12PA", "currentPrice": { "amount": "$1,529.00", "raw_amount": "1529.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini Apple M1 Chip with 8‑Core CPU and 8‑Core GPU, 10GB Ethernet", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2020?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1614364640000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1614364640000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2020", "originalImageName": "refurb-mac-mini-2020", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G12PALL/A/Refurbished-Mac-mini-Apple-M1-Chip-with-8%E2%80%91Core-CPU-and-8%E2%80%91Core-GPU-10GB-Ethernet?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 97, "priceAsc": 41 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G12PALL/A", "basePartNumber": "G12PA", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0VY2LL/A", "sortOrder": 42, "filters": { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0VY2LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0VY2", "currentPrice": { "amount": "$1,569.00", "raw_amount": "1569.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display and Radeon Pro Vega 20", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087778", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087778" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-215-gallery", "originalImageName": "refurb-2019-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0VY2LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display-and-Radeon-Pro-Vega-20?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 96, "priceAsc": 42 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0VY2LL/A", "basePartNumber": "G0VY2", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0VY0LL/A", "sortOrder": 43, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0VY0LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0VY0", "currentPrice": { "amount": "$1,569.00", "raw_amount": "1569.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display and Radeon Pro Vega 20", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087778", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087778" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-215-gallery", "originalImageName": "refurb-2019-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0VY0LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display-and-Radeon-Pro-Vega-20?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 95, "priceAsc": 43 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0VY0LL/A", "basePartNumber": "G0VY0", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0VY5LL/A", "sortOrder": 44, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0VY5LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0VY5", "currentPrice": { "amount": "$1,609.00", "raw_amount": "1609.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087778", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087778" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-215-gallery", "originalImageName": "refurb-2019-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0VY5LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 94, "priceAsc": 44 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0VY5LL/A", "basePartNumber": "G0VY5", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G11L1LL/A", "sortOrder": 45, "filters": { "dimensions": { "dimensionCapacity": "512gb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "32gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G11L1LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G11L1", "currentPrice": { "amount": "$1,609.00", "raw_amount": "1609.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1553797551145", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1553797551145" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2018", "originalImageName": "refurb-mac-mini-2018", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G11L1LL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 93, "priceAsc": 45 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G11L1LL/A", "basePartNumber": "G11L1", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0VYBLL/A", "sortOrder": 46, "filters": { "dimensions": { "dimensionCapacity": "512gb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0VYBLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0VYB", "currentPrice": { "amount": "$1,609.00", "raw_amount": "1609.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087778", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087778" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-215-gallery", "originalImageName": "refurb-2019-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0VYBLL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 92, "priceAsc": 46 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0VYBLL/A", "basePartNumber": "G0VYB", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "GMW2LLL/A", "sortOrder": 47, "filters": { "dimensions": { "dimensionCapacity": "2tb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "GMW2LLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "GMW2L", "currentPrice": { "amount": "$1,609.00", "raw_amount": "1609.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1553797551145", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1553797551145" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2018", "originalImageName": "refurb-mac-mini-2018", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/GMW2LLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 91, "priceAsc": 47 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "GMW2LLL/A", "basePartNumber": "GMW2L", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0VYXLL/A", "sortOrder": 48, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0VYXLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0VYX", "currentPrice": { "amount": "$1,609.00", "raw_amount": "1609.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087778", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087778" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-215-gallery", "originalImageName": "refurb-2019-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0VYXLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 90, "priceAsc": 48 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0VYXLL/A", "basePartNumber": "G0VYX", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0VYZLL/A", "sortOrder": 49, "filters": { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0VYZLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0VYZ", "currentPrice": { "amount": "$1,609.00", "raw_amount": "1609.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087778", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087778" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-215-gallery", "originalImageName": "refurb-2019-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0VYZLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 89, "priceAsc": 49 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0VYZLL/A", "basePartNumber": "G0VYZ", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0VYTLL/A", "sortOrder": 50, "filters": { "dimensions": { "dimensionCapacity": "512gb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0VYTLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0VYT", "currentPrice": { "amount": "$1,609.00", "raw_amount": "1609.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087778", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087778" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-215-gallery", "originalImageName": "refurb-2019-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0VYTLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 88, "priceAsc": 50 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0VYTLL/A", "basePartNumber": "G0VYT", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0VYQLL/A", "sortOrder": 51, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0VYQLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0VYQ", "currentPrice": { "amount": "$1,739.00", "raw_amount": "1739.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display and Radeon Pro Vega 20", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087778", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087778" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-215-gallery", "originalImageName": "refurb-2019-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0VYQLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display-and-Radeon-Pro-Vega-20?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 87, "priceAsc": 51 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0VYQLL/A", "basePartNumber": "G0VYQ", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G11L3LL/A", "sortOrder": 52, "filters": { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "32gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G11L3LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G11L3", "currentPrice": { "amount": "$1,779.00", "raw_amount": "1779.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1553797551145", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1553797551145" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2018", "originalImageName": "refurb-mac-mini-2018", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G11L3LL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 86, "priceAsc": 52 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G11L3LL/A", "basePartNumber": "G11L3", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0VQ3LL/A", "sortOrder": 53, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "27inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0VQ3LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0VQ3", "currentPrice": { "amount": "$1,779.00", "raw_amount": "1779.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087002", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087002" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-27-gallery", "originalImageName": "refurb-2019-imac-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0VQ3LL/A/Refurbished-27-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 85, "priceAsc": 53 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0VQ3LL/A", "basePartNumber": "G0VQ3", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0W2YLL/A", "sortOrder": 54, "filters": { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "32gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0W2YLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0W2Y", "currentPrice": { "amount": "$1,779.00", "raw_amount": "1779.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1553797551145", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1553797551145" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2018", "originalImageName": "refurb-mac-mini-2018", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0W2YLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 84, "priceAsc": 54 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0W2YLL/A", "basePartNumber": "G0W2Y", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0VYDLL/A", "sortOrder": 55, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0VYDLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0VYD", "currentPrice": { "amount": "$1,779.00", "raw_amount": "1779.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087778", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087778" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-215-gallery", "originalImageName": "refurb-2019-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0VYDLL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 83, "priceAsc": 55 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0VYDLL/A", "basePartNumber": "G0VYD", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "FJMV3LL/A", "sortOrder": 56, "filters": { "dimensions": { "dimensionCapacity": "512gb", "refurbClearModel": "macstudio", "dimensionRelYear": "2022" } }, "price": { "priceFeeDisclaimer": "", "previousPrice": { "amount": null, "raw_amount": "1799.00", "previousPrice": "<span class = \"was-text\">Was</span> $1,999.00" }, "savings": "Save $200.00", "priceCurrency": "USD", "partNumber": "FJMV3LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "FJMV3", "originalProductAmount": 1999.00, "currentPrice": { "amount": "$1,799.00", "raw_amount": "1799.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac Studio Apple M1 Max Chip with 10‑Core CPU and 24‑Core GPU", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-studio-202203?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1653413024271", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1653413024271" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-studio-202203", "originalImageName": "refurb-mac-studio-202203", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/FJMV3LL/A/refurbished-mac-studio-apple-m1-max-chip-with-10%E2%80%91core-cpu-and-24%E2%80%91core-gpu?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 82, "priceAsc": 56 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "FJMV3LL/A", "basePartNumber": "FJMV3", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "GMW2ALL/A", "sortOrder": 57, "filters": { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "32gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "GMW2ALL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "GMW2A", "currentPrice": { "amount": "$1,869.00", "raw_amount": "1869.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1553797551145", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1553797551145" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2018", "originalImageName": "refurb-mac-mini-2018", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/GMW2ALL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 81, "priceAsc": 57 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "GMW2ALL/A", "basePartNumber": "GMW2A", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0VR4LL/A", "sortOrder": 58, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "27inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0VR4LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0VR4", "currentPrice": { "amount": "$1,869.00", "raw_amount": "1869.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac 3.1GHz 6-core Intel Core i5 with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087002", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087002" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-27-gallery", "originalImageName": "refurb-2019-imac-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0VR4LL/A/Refurbished-27-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 80, "priceAsc": 58 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0VR4LL/A", "basePartNumber": "G0VR4", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0VY6LL/A", "sortOrder": 59, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0VY6LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0VY6", "currentPrice": { "amount": "$1,909.00", "raw_amount": "1909.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display and Radeon Pro Vega 20", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087778", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087778" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-215-gallery", "originalImageName": "refurb-2019-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0VY6LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display-and-Radeon-Pro-Vega-20?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 79, "priceAsc": 59 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0VY6LL/A", "basePartNumber": "G0VY6", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0VYCLL/A", "sortOrder": 60, "filters": { "dimensions": { "dimensionCapacity": "512gb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0VYCLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0VYC", "currentPrice": { "amount": "$1,909.00", "raw_amount": "1909.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display and Radeon Pro Vega 20", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087778", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087778" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-215-gallery", "originalImageName": "refurb-2019-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0VYCLL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display-and-Radeon-Pro-Vega-20?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 78, "priceAsc": 60 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0VYCLL/A", "basePartNumber": "G0VYC", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "GMVY3LL/A", "sortOrder": 61, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "GMVY3LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "GMVY3", "currentPrice": { "amount": "$1,949.00", "raw_amount": "1949.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087778", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087778" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-215-gallery", "originalImageName": "refurb-2019-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/GMVY3LL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 77, "priceAsc": 61 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "GMVY3LL/A", "basePartNumber": "GMVY3", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G14J0LL/A", "sortOrder": 62, "filters": { "dimensions": { "refurbClearModel": "macstudio", "dimensionRelYear": "2022" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G14J0LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G14J0", "currentPrice": { "amount": "$1,979.00", "raw_amount": "1979.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac Studio Apple M1 Max Chip with 10‑Core CPU and 24‑Core GPU", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-studio-202203?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1653413024271", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1653413024271" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-studio-202203", "originalImageName": "refurb-mac-studio-202203", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G14J0LL/A/refurbished-mac-studio-apple-m1-max-chip-with-10%E2%80%91core-cpu-and-24%E2%80%91core-gpu?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 76, "priceAsc": 62 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G14J0LL/A", "basePartNumber": "G14J0", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G14J9LL/A", "sortOrder": 63, "filters": { "dimensions": { "dimensionCapacity": "512gb", "refurbClearModel": "macstudio", "dimensionRelYear": "2022" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G14J9LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G14J9", "currentPrice": { "amount": "$1,979.00", "raw_amount": "1979.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac Studio Apple M1 Max Chip with 10‑Core CPU and 32‑Core GPU", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-studio-202203?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1653413024271", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1653413024271" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-studio-202203", "originalImageName": "refurb-mac-studio-202203", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G14J9LL/A/refurbished-mac-studio-apple-m1-max-chip-with-10%E2%80%91core-cpu-and-32%E2%80%91core-gpu?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 75, "priceAsc": 63 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G14J9LL/A", "basePartNumber": "G14J9", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G14JALL/A", "sortOrder": 64, "filters": { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macstudio", "dimensionRelYear": "2022" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G14JALL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G14JA", "currentPrice": { "amount": "$2,159.00", "raw_amount": "2159.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac Studio Apple M1 Max Chip with 10‑Core CPU and 32‑Core GPU", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-studio-202203?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1653413024271", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1653413024271" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-studio-202203", "originalImageName": "refurb-mac-studio-202203", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G14JALL/A/refurbished-mac-studio-apple-m1-max-chip-with-10%E2%80%91core-cpu-and-32%E2%80%91core-gpu?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 74, "priceAsc": 64 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G14JALL/A", "basePartNumber": "G14JA", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "GMW2DLL/A", "sortOrder": 65, "filters": { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "GMW2DLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "GMW2D", "currentPrice": { "amount": "$2,209.00", "raw_amount": "2209.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1553797551145", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1553797551145" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2018", "originalImageName": "refurb-mac-mini-2018", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/GMW2DLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 73, "priceAsc": 65 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "GMW2DLL/A", "basePartNumber": "GMW2D", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "GMVY4LL/A", "sortOrder": 66, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "GMVY4LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "GMVY4", "currentPrice": { "amount": "$2,249.00", "raw_amount": "2249.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display and Radeon Pro Vega 20", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087778", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087778" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-215-gallery", "originalImageName": "refurb-2019-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/GMVY4LL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display-and-Radeon-Pro-Vega-20?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 72, "priceAsc": 66 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "GMVY4LL/A", "basePartNumber": "GMVY4", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "FK1E3LL/A", "sortOrder": 67, "filters": { "dimensions": { "dimensionCapacity": "512gb", "dimensionScreensize": "16inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2021", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "previousPrice": { "amount": null, "raw_amount": "2249.00", "previousPrice": "<span class = \"was-text\">Was</span> $2,499.00" }, "savings": "Save $250.00", "priceCurrency": "USD", "partNumber": "FK1E3LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "FK1E3", "originalProductAmount": 2499.00, "currentPrice": { "amount": "$2,249.00", "raw_amount": "2249.00" }, "adjustedPrice": {} }, "title": "Refurbished 16-inch MacBook Pro Apple M1 Pro Chip with 10‑Core CPU and 16‑Core GPU - Silver", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp16-silver-m1-2021?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1643239832000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1643239832000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mbp16-silver-m1-2021", "originalImageName": "refurb-mbp16-silver-m1-2021", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/FK1E3LL/A/refurbished-16-inch-macbook-pro-apple-m1-pro-chip-with-10%E2%80%91core-cpu-and-16%E2%80%91core-gpu-silver?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 71, "priceAsc": 67 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "FK1E3LL/A", "basePartNumber": "FK1E3", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "FKGT3LL/A", "sortOrder": 68, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "14inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2021", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "previousPrice": { "amount": null, "raw_amount": "2249.00", "previousPrice": "<span class = \"was-text\">Was</span> $2,499.00" }, "savings": "Save $250.00", "priceCurrency": "USD", "partNumber": "FKGT3LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "FKGT3", "originalProductAmount": 2499.00, "currentPrice": { "amount": "$2,249.00", "raw_amount": "2249.00" }, "adjustedPrice": {} }, "title": "Refurbished 14-inch MacBook Pro Apple M1 Pro Chip with 10‑Core CPU and 16‑Core GPU - Silver", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp14-silver-m1-2021?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1638576254000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1638576254000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mbp14-silver-m1-2021", "originalImageName": "refurb-mbp14-silver-m1-2021", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/FKGT3LL/A/refurbished-14-inch-macbook-pro-apple-m1-pro-chip-with-10%E2%80%91core-cpu-and-16%E2%80%91core-gpu-silver?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 70, "priceAsc": 68 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "FKGT3LL/A", "basePartNumber": "FKGT3", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "FKGQ3LL/A", "sortOrder": 69, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "14inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2021", "dimensionColor": "space_gray", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "previousPrice": { "amount": null, "raw_amount": "2249.00", "previousPrice": "<span class = \"was-text\">Was</span> $2,499.00" }, "savings": "Save $250.00", "priceCurrency": "USD", "partNumber": "FKGQ3LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "FKGQ3", "originalProductAmount": 2499.00, "currentPrice": { "amount": "$2,249.00", "raw_amount": "2249.00" }, "adjustedPrice": {} }, "title": "Refurbished 14-inch MacBook Pro Apple M1 Pro Chip with 10‑Core CPU and 16‑Core GPU - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp14-space-m1-2021?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1638575247000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1638575247000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mbp14-space-m1-2021", "originalImageName": "refurb-mbp14-space-m1-2021", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/FKGQ3LL/A/refurbished-14-inch-macbook-pro-apple-m1-pro-chip-with-10%E2%80%91core-cpu-and-16%E2%80%91core-gpu-space-gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 69, "priceAsc": 69 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "FKGQ3LL/A", "basePartNumber": "FKGQ3", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "FK183LL/A", "sortOrder": 70, "filters": { "dimensions": { "dimensionCapacity": "512gb", "dimensionScreensize": "16inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2021", "dimensionColor": "space_gray", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "previousPrice": { "amount": null, "raw_amount": "2249.00", "previousPrice": "<span class = \"was-text\">Was</span> $2,499.00" }, "savings": "Save $250.00", "priceCurrency": "USD", "partNumber": "FK183LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "FK183", "originalProductAmount": 2499.00, "currentPrice": { "amount": "$2,249.00", "raw_amount": "2249.00" }, "adjustedPrice": {} }, "title": "Refurbished 16-inch MacBook Pro Apple M1 Pro Chip with 10‑Core CPU and 16‑Core GPU - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp16-space-m1-2021?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1643239951000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1643239951000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mbp16-space-m1-2021", "originalImageName": "refurb-mbp16-space-m1-2021", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/FK183LL/A/refurbished-16-inch-macbook-pro-apple-m1-pro-chip-with-10%E2%80%91core-cpu-and-16%E2%80%91core-gpu-space-gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 68, "priceAsc": 70 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "FK183LL/A", "basePartNumber": "FK183", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "FK1F3LL/A", "sortOrder": 71, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "16inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2021", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "previousPrice": { "amount": null, "raw_amount": "2429.00", "previousPrice": "<span class = \"was-text\">Was</span> $2,699.00" }, "savings": "Save $270.00", "priceCurrency": "USD", "partNumber": "FK1F3LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "FK1F3", "originalProductAmount": 2699.00, "currentPrice": { "amount": "$2,429.00", "raw_amount": "2429.00" }, "adjustedPrice": {} }, "title": "Refurbished 16-inch MacBook Pro Apple M1 Pro Chip with 10‑Core CPU and 16‑Core GPU - Silver", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp16-silver-m1-2021?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1643239832000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1643239832000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mbp16-silver-m1-2021", "originalImageName": "refurb-mbp16-silver-m1-2021", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/FK1F3LL/A/refurbished-16-inch-macbook-pro-apple-m1-pro-chip-with-10%E2%80%91core-cpu-and-16%E2%80%91core-gpu-silver?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 67, "priceAsc": 71 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "FK1F3LL/A", "basePartNumber": "FK1F3", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G11LBLL/A", "sortOrder": 72, "filters": { "dimensions": { "dimensionCapacity": "2tb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G11LBLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G11LB", "currentPrice": { "amount": "$2,459.00", "raw_amount": "2459.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1553797551145", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1553797551145" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2018", "originalImageName": "refurb-mac-mini-2018", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G11LBLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 66, "priceAsc": 72 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G11LBLL/A", "basePartNumber": "G11LB", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "GMW22LL/A", "sortOrder": 73, "filters": { "dimensions": { "dimensionCapacity": "2tb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "GMW22LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "GMW22", "currentPrice": { "amount": "$2,459.00", "raw_amount": "2459.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1553797551145", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1553797551145" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2018", "originalImageName": "refurb-mac-mini-2018", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/GMW22LL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 65, "priceAsc": 73 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "GMW22LL/A", "basePartNumber": "GMW22", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "GMW2ELL/A", "sortOrder": 74, "filters": { "dimensions": { "dimensionCapacity": "2tb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "GMW2ELL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "GMW2E", "currentPrice": { "amount": "$2,549.00", "raw_amount": "2549.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1553797551145", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1553797551145" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2018", "originalImageName": "refurb-mac-mini-2018", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/GMW2ELL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 64, "priceAsc": 74 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "GMW2ELL/A", "basePartNumber": "GMW2E", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G11LCLL/A", "sortOrder": 75, "filters": { "dimensions": { "dimensionCapacity": "2tb", "refurbClearModel": "macmini", "dimensionRelYear": "2018", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G11LCLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G11LC", "currentPrice": { "amount": "$2,549.00", "raw_amount": "2549.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac mini 3.2GHz 6-core Intel Core i7, 10GB Ethernet - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-mini-2018?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1553797551145", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1553797551145" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-mini-2018", "originalImageName": "refurb-mac-mini-2018", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G11LCLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 63, "priceAsc": 75 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G11LCLL/A", "basePartNumber": "G11LC", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "GMVYCLL/A", "sortOrder": 76, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "21_5inch", "refurbClearModel": "imac", "dimensionRelYear": "2019", "dimensionColor": "silver", "tsMemorySize": "32gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "GMVYCLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "GMVYC", "currentPrice": { "amount": "$2,589.00", "raw_amount": "2589.00" }, "adjustedPrice": {} }, "title": "Refurbished 21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display and Radeon Pro Vega 20", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2019-imac-215-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1559961087778", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1559961087778" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2019-imac-215-gallery", "originalImageName": "refurb-2019-imac-215-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/GMVYCLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display-and-Radeon-Pro-Vega-20?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 62, "priceAsc": 76 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "GMVYCLL/A", "basePartNumber": "GMVYC", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "FK1H3LL/A", "sortOrder": 77, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "16inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2021", "dimensionColor": "silver", "tsMemorySize": "32gb" } }, "price": { "priceFeeDisclaimer": "", "previousPrice": { "amount": null, "raw_amount": "3149.00", "previousPrice": "<span class = \"was-text\">Was</span> $3,499.00" }, "savings": "Save $350.00", "priceCurrency": "USD", "partNumber": "FK1H3LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "FK1H3", "originalProductAmount": 3499.00, "currentPrice": { "amount": "$3,149.00", "raw_amount": "3149.00" }, "adjustedPrice": {} }, "title": "Refurbished 16-inch MacBook Pro Apple M1 Max Chip with 10‑Core CPU and 32‑Core GPU - Silver", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp16-silver-m1-2021?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1643239832000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1643239832000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mbp16-silver-m1-2021", "originalImageName": "refurb-mbp16-silver-m1-2021", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/FK1H3LL/A/refurbished-16-inch-macbook-pro-apple-m1-max-chip-with-10%E2%80%91core-cpu-and-32%E2%80%91core-gpu-silver?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 61, "priceAsc": 77 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "FK1H3LL/A", "basePartNumber": "FK1H3", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0ZV2LL/A", "sortOrder": 78, "filters": { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "27inch", "refurbClearModel": "imac", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "128gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0ZV2LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0ZV2", "currentPrice": { "amount": "$3,179.00", "raw_amount": "3179.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac 3.1GHz 6-core Intel Core i5 with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-imac-27-2020?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1654865822599", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1654865822599" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-imac-27-2020", "originalImageName": "refurb-imac-27-2020", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0ZV2LL/A/refurbished-27-inch-imac-31GHz-6-core-Intel-Core-i5-with-retina-5k-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 60, "priceAsc": 78 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0ZV2LL/A", "basePartNumber": "G0ZV2", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0ZV7LL/A", "sortOrder": 79, "filters": { "dimensions": { "dimensionCapacity": "256gb", "dimensionScreensize": "27inch", "refurbClearModel": "imac", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "128gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0ZV7LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0ZV7", "currentPrice": { "amount": "$3,249.00", "raw_amount": "3249.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac 3.1GHz 6-core Intel Core i5 with Retina 5K display, 10GB Ethernet", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-imac-27-2020?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1654865822599", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1654865822599" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-imac-27-2020", "originalImageName": "refurb-imac-27-2020", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0ZV7LL/A/Refurbished-27-inch-iMac-31GHz-6-core-Intel-Core-i5-with-Retina-5K-display-10GB-Ethernet?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 59, "priceAsc": 79 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0ZV7LL/A", "basePartNumber": "G0ZV7", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "FQ2Y2LL/A", "sortOrder": 80, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "32gb" } }, "price": { "priceFeeDisclaimer": "", "previousPrice": { "amount": null, "raw_amount": "3249.00", "previousPrice": "<span class = \"was-text\">Was</span> $4,499.00" }, "savings": "Save $1,250.00", "priceCurrency": "USD", "partNumber": "FQ2Y2LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "FQ2Y2", "originalProductAmount": 4499.00, "currentPrice": { "amount": "$3,249.00", "raw_amount": "3249.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 3.2GHz 8-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/FQ2Y2LL/A/Refurbished-27-inch-iMac-Pro-32GHz-8-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 58, "priceAsc": 80 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "FQ2Y2LL/A", "basePartNumber": "FQ2Y2", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G15HKLL/A", "sortOrder": 81, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "14inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2021", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G15HKLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G15HK", "currentPrice": { "amount": "$3,329.00", "raw_amount": "3329.00" }, "adjustedPrice": {} }, "title": "Refurbished 14-inch MacBook Pro Apple M1 Max Chip with 10‑Core CPU and 32‑Core GPU - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp14-space-m1-2021?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1638575247000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1638575247000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mbp14-space-m1-2021", "originalImageName": "refurb-mbp14-space-m1-2021", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G15HKLL/A/refurbished-14-inch-macbook-pro-apple-m1-max-chip-with-10%E2%80%91core-cpu-and-32%E2%80%91core-gpu-space-gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 57, "priceAsc": 81 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G15HKLL/A", "basePartNumber": "G15HK", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G16P9LL/A", "sortOrder": 82, "filters": { "dimensions": { "dimensionCapacity": "8tb", "dimensionScreensize": "27inch", "refurbClearModel": "imac", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G16P9LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G16P9", "currentPrice": { "amount": "$3,679.00", "raw_amount": "3679.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac 3.8GHz 8-core Intel Core i7 with Retina 5K display, 10GB Ethernet", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-imac-27-2020?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1654865822599", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1654865822599" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-imac-27-2020", "originalImageName": "refurb-imac-27-2020", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G16P9LL/A/refurbished-27-inch-imac-38ghz-8-core-intel-core-i7-with-retina-5k-display-10gb-ethernet?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 56, "priceAsc": 82 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G16P9LL/A", "basePartNumber": "G16P9", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G15HLLL/A", "sortOrder": 83, "filters": { "dimensions": { "dimensionCapacity": "2tb", "dimensionScreensize": "14inch", "refurbClearModel": "macbookpro", "dimensionRelYear": "2021", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G15HLLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G15HL", "currentPrice": { "amount": "$3,689.00", "raw_amount": "3689.00" }, "adjustedPrice": {} }, "title": "Refurbished 14-inch MacBook Pro Apple M1 Max Chip with 10‑Core CPU and 32‑Core GPU - Space Gray", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mbp14-space-m1-2021?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1638575247000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1638575247000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mbp14-space-m1-2021", "originalImageName": "refurb-mbp14-space-m1-2021", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G15HLLL/A/refurbished-14-inch-macbook-pro-apple-m1-max-chip-with-10%E2%80%91core-cpu-and-32%E2%80%91core-gpu-space-gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 55, "priceAsc": 83 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G15HLLL/A", "basePartNumber": "G15HL", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G16P5LL/A", "sortOrder": 84, "filters": { "dimensions": { "dimensionCapacity": "8tb", "dimensionScreensize": "27inch", "refurbClearModel": "imac", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "8gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G16P5LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G16P5", "currentPrice": { "amount": "$3,759.00", "raw_amount": "3759.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac 3.6GHz 10-core Intel Core i9 with Retina 5K display, 10GB Ethernet", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-imac-27-2020?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1654865822599", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1654865822599" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-imac-27-2020", "originalImageName": "refurb-imac-27-2020", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G16P5LL/A/refurbished-27-inch-imac-36ghz-10-core-intel-core-i9-with-retina-5k-display-10gb-ethernet?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 54, "priceAsc": 84 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G16P5LL/A", "basePartNumber": "G16P5", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G11P5LL/A", "sortOrder": 85, "filters": { "dimensions": { "dimensionCapacity": "8tb", "dimensionScreensize": "27inch", "refurbClearModel": "imac", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "16gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G11P5LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G11P5", "currentPrice": { "amount": "$3,819.00", "raw_amount": "3819.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac 3.6GHz 10-core Intel Core i9 with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-imac-27-2020?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1654865822599", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1654865822599" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-imac-27-2020", "originalImageName": "refurb-imac-27-2020", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G11P5LL/A/refurbished-27-inch-imac-36ghz-10-core-intel-core-i9-with-retina-5k-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 53, "priceAsc": 85 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G11P5LL/A", "basePartNumber": "G11P5", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0URYLL/A", "sortOrder": 86, "filters": { "dimensions": { "dimensionCapacity": "2tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "32gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0URYLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0URY", "currentPrice": { "amount": "$4,159.00", "raw_amount": "4159.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 3.2GHz 8-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0URYLL/A/Refurbished-27-inch-iMac-Pro-32GHz-8-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 52, "priceAsc": 86 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0URYLL/A", "basePartNumber": "G0URY", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0URNLL/A", "sortOrder": 87, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "32gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0URNLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0URN", "currentPrice": { "amount": "$4,249.00", "raw_amount": "4249.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0URNLL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 51, "priceAsc": 87 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0URNLL/A", "basePartNumber": "G0URN", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0URKLL/A", "sortOrder": 88, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "32gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0URKLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0URK", "currentPrice": { "amount": "$4,289.00", "raw_amount": "4289.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 3.2GHz 8-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0URKLL/A/Refurbished-27-inch-iMac-Pro-32GHz-8-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 50, "priceAsc": 88 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0URKLL/A", "basePartNumber": "G0URK", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G11QULL/A", "sortOrder": 89, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "27inch", "refurbClearModel": "imac", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "128gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G11QULL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G11QU", "currentPrice": { "amount": "$4,329.00", "raw_amount": "4329.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac 3.6GHz 10-core Intel Core i9 with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-imac-27-2020?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1654865822599", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1654865822599" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-imac-27-2020", "originalImageName": "refurb-imac-27-2020", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G11QULL/A/Refurbished-27-inch-iMac-36GHz-10-core-Intel-Core-i9-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 49, "priceAsc": 89 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G11QULL/A", "basePartNumber": "G11QU", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G11PELL/A", "sortOrder": 90, "filters": { "dimensions": { "dimensionCapacity": "2tb", "dimensionScreensize": "27inch", "refurbClearModel": "imac", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "128gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G11PELL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G11PE", "currentPrice": { "amount": "$4,479.00", "raw_amount": "4479.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac 3.6GHz 10-core Intel Core i9 with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-imac-27-2020?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1654865822599", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1654865822599" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-imac-27-2020", "originalImageName": "refurb-imac-27-2020", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G11PELL/A/Refurbished-27-inch-iMac-36GHz-10-core-Intel-Core-i9-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 48, "priceAsc": 90 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G11PELL/A", "basePartNumber": "G11PE", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0UR3LL/A", "sortOrder": 91, "filters": { "dimensions": { "dimensionCapacity": "2tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "32gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0UR3LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0UR3", "currentPrice": { "amount": "$4,589.00", "raw_amount": "4589.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0UR3LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 47, "priceAsc": 91 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0UR3LL/A", "basePartNumber": "G0UR3", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0UR5LL/A", "sortOrder": 92, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0UR5LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0UR5", "currentPrice": { "amount": "$4,589.00", "raw_amount": "4589.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0UR5LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 46, "priceAsc": 92 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0UR5LL/A", "basePartNumber": "G0UR5", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0UR0LL/A", "sortOrder": 93, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0UR0LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0UR0", "currentPrice": { "amount": "$4,629.00", "raw_amount": "4629.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 3.2GHz 8-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0UR0LL/A/Refurbished-27-inch-iMac-Pro-32GHz-8-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 45, "priceAsc": 93 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0UR0LL/A", "basePartNumber": "G0UR0", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0URXLL/A", "sortOrder": 94, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "32gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0URXLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0URX", "currentPrice": { "amount": "$4,719.00", "raw_amount": "4719.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0URXLL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 44, "priceAsc": 94 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0URXLL/A", "basePartNumber": "G0URX", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0UR7LL/A", "sortOrder": 95, "filters": { "dimensions": { "dimensionCapacity": "2tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0UR7LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0UR7", "currentPrice": { "amount": "$4,929.00", "raw_amount": "4929.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0UR7LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 43, "priceAsc": 95 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0UR7LL/A", "basePartNumber": "G0UR7", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0URQLL/A", "sortOrder": 96, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "32gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0URQLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0URQ", "currentPrice": { "amount": "$4,929.00", "raw_amount": "4929.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0URQLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 42, "priceAsc": 96 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0URQLL/A", "basePartNumber": "G0URQ", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0UR4LL/A", "sortOrder": 97, "filters": { "dimensions": { "dimensionCapacity": "2tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "32gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0UR4LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0UR4", "currentPrice": { "amount": "$5,059.00", "raw_amount": "5059.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0UR4LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 41, "priceAsc": 97 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0UR4LL/A", "basePartNumber": "G0UR4", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0UR6LL/A", "sortOrder": 98, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0UR6LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0UR6", "currentPrice": { "amount": "$5,059.00", "raw_amount": "5059.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0UR6LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 40, "priceAsc": 98 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0UR6LL/A", "basePartNumber": "G0UR6", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "GPURYLL/A", "sortOrder": 99, "filters": { "dimensions": { "dimensionCapacity": "4tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "32gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "GPURYLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "GPURY", "currentPrice": { "amount": "$5,099.00", "raw_amount": "5099.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/GPURYLL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 39, "priceAsc": 99 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "GPURYLL/A", "basePartNumber": "GPURY", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "GNURELL/A", "sortOrder": 100, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "GNURELL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "GNURE", "currentPrice": { "amount": "$5,179.00", "raw_amount": "5179.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display and Radeon Pro Vega 64X", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/GNURELL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display-and-Radeon-Pro-Vega-64X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 38, "priceAsc": 100 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "GNURELL/A", "basePartNumber": "GNURE", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0W30LL/A", "sortOrder": 101, "filters": { "dimensions": { "dimensionCapacity": "256gb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "48gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0W30LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0W30", "currentPrice": { "amount": "$5,179.00", "raw_amount": "5179.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac Pro 3.5GHz 8-core Intel Xeon W, Radeon Pro 580X", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-2019?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1585849394561", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1585849394561" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-pro-2019", "originalImageName": "refurb-mac-pro-2019", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0W30LL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 37, "priceAsc": 101 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0W30LL/A", "basePartNumber": "G0W30", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "GMURKLL/A", "sortOrder": 102, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "GMURKLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "GMURK", "currentPrice": { "amount": "$5,269.00", "raw_amount": "5269.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/GMURKLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 36, "priceAsc": 102 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "GMURKLL/A", "basePartNumber": "GMURK", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "GMURJLL/A", "sortOrder": 103, "filters": { "dimensions": { "dimensionCapacity": "2tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "32gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "GMURJLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "GMURJ", "currentPrice": { "amount": "$5,269.00", "raw_amount": "5269.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/GMURJLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 35, "priceAsc": 103 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "GMURJLL/A", "basePartNumber": "GMURJ", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "GMURHLL/A", "sortOrder": 104, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "32gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "GMURHLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "GMURH", "currentPrice": { "amount": "$5,399.00", "raw_amount": "5399.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/GMURHLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 34, "priceAsc": 104 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "GMURHLL/A", "basePartNumber": "GMURH", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0UR8LL/A", "sortOrder": 105, "filters": { "dimensions": { "dimensionCapacity": "2tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0UR8LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0UR8", "currentPrice": { "amount": "$5,399.00", "raw_amount": "5399.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0UR8LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 33, "priceAsc": 105 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0UR8LL/A", "basePartNumber": "G0UR8", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0UR9LL/A", "sortOrder": 106, "filters": { "dimensions": { "dimensionCapacity": "4tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0UR9LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0UR9", "currentPrice": { "amount": "$5,439.00", "raw_amount": "5439.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0UR9LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 32, "priceAsc": 106 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0UR9LL/A", "basePartNumber": "G0UR9", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0URGLL/A", "sortOrder": 107, "filters": { "dimensions": { "dimensionCapacity": "2tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0URGLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0URG", "currentPrice": { "amount": "$5,609.00", "raw_amount": "5609.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0URGLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 31, "priceAsc": 107 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0URGLL/A", "basePartNumber": "G0URG", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G10K0LL/A", "sortOrder": 108, "filters": { "dimensions": { "dimensionCapacity": "256gb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "48gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G10K0LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G10K0", "currentPrice": { "amount": "$5,609.00", "raw_amount": "5609.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac Pro 3.5GHz 8-core Intel Xeon W, Radeon Pro 580X", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-rack-2019?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1605114669000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1605114669000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-pro-rack-2019", "originalImageName": "refurb-mac-pro-rack-2019", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G10K0LL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 30, "priceAsc": 108 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G10K0LL/A", "basePartNumber": "G10K0", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "GMURLLL/A", "sortOrder": 109, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "GMURLLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "GMURL", "currentPrice": { "amount": "$5,739.00", "raw_amount": "5739.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/GMURLLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 29, "priceAsc": 109 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "GMURLLL/A", "basePartNumber": "GMURL", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0URALL/A", "sortOrder": 110, "filters": { "dimensions": { "dimensionCapacity": "4tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0URALL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0URA", "currentPrice": { "amount": "$5,909.00", "raw_amount": "5909.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0URALL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 28, "priceAsc": 110 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0URALL/A", "basePartNumber": "G0URA", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0URDLL/A", "sortOrder": 111, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0URDLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0URD", "currentPrice": { "amount": "$5,949.00", "raw_amount": "5949.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 2.3GHz 18-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0URDLL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 27, "priceAsc": 111 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0URDLL/A", "basePartNumber": "G0URD", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G11R0LL/A", "sortOrder": 112, "filters": { "dimensions": { "dimensionCapacity": "8tb", "dimensionScreensize": "27inch", "refurbClearModel": "imac", "dimensionRelYear": "2020", "dimensionColor": "silver", "tsMemorySize": "128gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G11R0LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G11R0", "currentPrice": { "amount": "$5,989.00", "raw_amount": "5989.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac 3.6GHz 10-core Intel Core i9 with Retina 5K display, 10GB Ethernet", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-imac-27-2020?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1654865822599", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1654865822599" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-imac-27-2020", "originalImageName": "refurb-imac-27-2020", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G11R0LL/A/Refurbished-27-inch-iMac-36GHz-10-core-Intel-Core-i9-with-Retina-5K-display-10GB-Ethernet?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 26, "priceAsc": 112 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G11R0LL/A", "basePartNumber": "G11R0", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G1434LL/A", "sortOrder": 113, "filters": { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "48gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G1434LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G1434", "currentPrice": { "amount": "$6,029.00", "raw_amount": "6029.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac Pro 3.5GHz 8-core Intel Xeon W, Radeon Pro W5700X", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-2019?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1585849394561", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1585849394561" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-pro-2019", "originalImageName": "refurb-mac-pro-2019", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G1434LL/A/refurbished-mac-pro-35ghz-8-core-intel-xeon-w-radeon-pro-w5700x?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 25, "priceAsc": 113 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G1434LL/A", "basePartNumber": "G1434", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0URHLL/A", "sortOrder": 114, "filters": { "dimensions": { "dimensionCapacity": "2tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0URHLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0URH", "currentPrice": { "amount": "$6,079.00", "raw_amount": "6079.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0URHLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 24, "priceAsc": 114 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0URHLL/A", "basePartNumber": "G0URH", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G10K2LL/A", "sortOrder": 115, "filters": { "dimensions": { "dimensionCapacity": "2tb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "48gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G10K2LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G10K2", "currentPrice": { "amount": "$6,289.00", "raw_amount": "6289.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac Pro 3.5GHz 8-core Intel Xeon W, Radeon Pro 580X", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-rack-2019?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1605114669000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1605114669000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-pro-rack-2019", "originalImageName": "refurb-mac-pro-rack-2019", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G10K2LL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 23, "priceAsc": 115 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G10K2LL/A", "basePartNumber": "G10K2", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0URBLL/A", "sortOrder": 116, "filters": { "dimensions": { "dimensionCapacity": "2tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "128gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0URBLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0URB", "currentPrice": { "amount": "$6,289.00", "raw_amount": "6289.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0URBLL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 22, "priceAsc": 116 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0URBLL/A", "basePartNumber": "G0URB", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "GMURDLL/A", "sortOrder": 117, "filters": { "dimensions": { "dimensionCapacity": "2tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "GMURDLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "GMURD", "currentPrice": { "amount": "$6,289.00", "raw_amount": "6289.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 2.3GHz 18-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/GMURDLL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 21, "priceAsc": 117 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "GMURDLL/A", "basePartNumber": "GMURD", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0URSLL/A", "sortOrder": 118, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0URSLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0URS", "currentPrice": { "amount": "$6,419.00", "raw_amount": "6419.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 2.3GHz 18-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0URSLL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 20, "priceAsc": 118 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0URSLL/A", "basePartNumber": "G0URS", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0W36LL/A", "sortOrder": 119, "filters": { "dimensions": { "dimensionCapacity": "256gb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "96gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0W36LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0W36", "currentPrice": { "amount": "$6,459.00", "raw_amount": "6459.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac Pro 3.5GHz 8-core Intel Xeon W, Radeon Pro 580X", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-2019?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1585849394561", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1585849394561" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-pro-2019", "originalImageName": "refurb-mac-pro-2019", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0W36LL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 19, "priceAsc": 119 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0W36LL/A", "basePartNumber": "G0W36", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0URCLL/A", "sortOrder": 120, "filters": { "dimensions": { "dimensionCapacity": "2tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "128gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0URCLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0URC", "currentPrice": { "amount": "$6,759.00", "raw_amount": "6759.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0URCLL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 18, "priceAsc": 120 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0URCLL/A", "basePartNumber": "G0URC", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "GNURZLL/A", "sortOrder": 121, "filters": { "dimensions": { "dimensionCapacity": "2tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "64gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "GNURZLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "GNURZ", "currentPrice": { "amount": "$6,879.00", "raw_amount": "6879.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 2.3GHz 18-core Intel Xeon W with Retina 5K display and Radeon Pro Vega 64X", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/GNURZLL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display-and-Radeon-Pro-Vega-64X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 17, "priceAsc": 121 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "GNURZLL/A", "basePartNumber": "GNURZ", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "GMURFLL/A", "sortOrder": 122, "filters": { "dimensions": { "dimensionCapacity": "1tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "128gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "GMURFLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "GMURF", "currentPrice": { "amount": "$7,309.00", "raw_amount": "7309.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 2.3GHz 18-core Intel Xeon W with Retina 5K display", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/GMURFLL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 16, "priceAsc": 122 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "GMURFLL/A", "basePartNumber": "GMURF", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G10LFLL/A", "sortOrder": 123, "filters": { "dimensions": { "dimensionCapacity": "256gb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "96gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G10LFLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G10LF", "currentPrice": { "amount": "$7,389.00", "raw_amount": "7389.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac Pro 3.3GHz 12-core Intel Xeon W, Radeon Pro 580X", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-rack-2019?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1605114669000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1605114669000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-pro-rack-2019", "originalImageName": "refurb-mac-pro-rack-2019", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G10LFLL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 15, "priceAsc": 123 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G10LFLL/A", "basePartNumber": "G10LF", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G143FLL/A", "sortOrder": 124, "filters": { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "96gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G143FLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G143F", "currentPrice": { "amount": "$7,479.00", "raw_amount": "7479.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac Pro 3.3GHz 12-core Intel Xeon W, Radeon Pro W5700X", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-2019?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1585849394561", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1585849394561" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-pro-2019", "originalImageName": "refurb-mac-pro-2019", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G143FLL/A/Refurbished-Mac-Pro-33GHz-12-core-Intel-Xeon-W-Radeon-Pro-W5700X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 14, "priceAsc": 124 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G143FLL/A", "basePartNumber": "G143F", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G10LGLL/A", "sortOrder": 125, "filters": { "dimensions": { "dimensionCapacity": "256gb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "96gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G10LGLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G10LG", "currentPrice": { "amount": "$7,729.00", "raw_amount": "7729.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac Pro 3.3GHz 12-core Intel Xeon W, Radeon Pro 580X", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-rack-2019?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1605114669000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1605114669000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-pro-rack-2019", "originalImageName": "refurb-mac-pro-rack-2019", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G10LGLL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 13, "priceAsc": 125 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G10LGLL/A", "basePartNumber": "G10LG", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G10MPLL/A", "sortOrder": 126, "filters": { "dimensions": { "dimensionCapacity": "2tb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "48gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G10MPLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G10MP", "currentPrice": { "amount": "$7,989.00", "raw_amount": "7989.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac Pro 3.2GHz 16-core Intel Xeon W, Radeon Pro 580X", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-rack-2019?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1605114669000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1605114669000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-pro-rack-2019", "originalImageName": "refurb-mac-pro-rack-2019", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G10MPLL/A/Refurbished-Mac-Pro-32GHz-16-core-Intel-Xeon-W-Radeon-Pro-580X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 12, "priceAsc": 126 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G10MPLL/A", "basePartNumber": "G10MP", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "GPURMLL/A", "sortOrder": 127, "filters": { "dimensions": { "dimensionCapacity": "4tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "128gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "GPURMLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "GPURM", "currentPrice": { "amount": "$8,069.00", "raw_amount": "8069.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display and Radeon Pro Vega 64X", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/GPURMLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display-and-Radeon-Pro-Vega-64X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 11, "priceAsc": 127 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "GPURMLL/A", "basePartNumber": "GPURM", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0ZDFLL/A", "sortOrder": 128, "filters": { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "96gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0ZDFLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0ZDF", "currentPrice": { "amount": "$8,159.00", "raw_amount": "8159.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac Pro 3.2GHz 16-core Intel Xeon W, Radeon Pro 580X", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-2019?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1585849394561", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1585849394561" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-pro-2019", "originalImageName": "refurb-mac-pro-2019", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0ZDFLL/A/Refurbished-Mac-Pro-32GHz-16-core-Intel-Xeon-W-Radeon-Pro-580X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 10, "priceAsc": 128 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0ZDFLL/A", "basePartNumber": "G0ZDF", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "GPUR2LL/A", "sortOrder": 129, "filters": { "dimensions": { "dimensionCapacity": "2tb", "dimensionScreensize": "27inch", "refurbClearModel": "imacpro2017", "dimensionRelYear": "2017", "dimensionColor": "space_gray", "tsMemorySize": "128gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "GPUR2LL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "GPUR2", "currentPrice": { "amount": "$8,239.00", "raw_amount": "8239.00" }, "adjustedPrice": {} }, "title": "Refurbished 27-inch iMac Pro 2.3GHz 18-core Intel Xeon W with Retina 5K display and Radeon Pro Vega 64X", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-2018-imac-pro-27-gallery?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1589235413137", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1589235413137" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-2018-imac-pro-27-gallery", "originalImageName": "refurb-2018-imac-pro-27-gallery", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/GPUR2LL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display-and-Radeon-Pro-Vega-64X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 9, "priceAsc": 129 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "GPUR2LL/A", "basePartNumber": "GPUR2", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G143ULL/A", "sortOrder": 130, "filters": { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "96gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G143ULL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G143U", "currentPrice": { "amount": "$8,579.00", "raw_amount": "8579.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac Pro 3.3GHz 12-core Intel Xeon W, Radeon Pro Vega II", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-2019?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1585849394561", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1585849394561" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-pro-2019", "originalImageName": "refurb-mac-pro-2019", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G143ULL/A/Refurbished-Mac-Pro-33GHz-12-core-Intel-Xeon-W-Radeon-Pro-Vega-II?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 8, "priceAsc": 130 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G143ULL/A", "basePartNumber": "G143U", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G10TWLL/A", "sortOrder": 131, "filters": { "dimensions": { "dimensionCapacity": "2tb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "48gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G10TWLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G10TW", "currentPrice": { "amount": "$9,179.00", "raw_amount": "9179.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac Pro 3.5GHz 8-core Intel Xeon W, Two Radeon Pro W5700X, Apple Afterburner", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-rack-2019?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1605114669000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1605114669000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-pro-rack-2019", "originalImageName": "refurb-mac-pro-rack-2019", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G10TWLL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Two-Radeon-Pro-W5700X-Apple-Afterburner?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 7, "priceAsc": 131 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G10TWLL/A", "basePartNumber": "G10TW", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G14GQLL/A", "sortOrder": 132, "filters": { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "48gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G14GQLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G14GQ", "currentPrice": { "amount": "$9,429.00", "raw_amount": "9429.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac Pro 3.2GHz 16-core Intel Xeon W, Radeon Pro W6800X", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-2019?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1585849394561", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1585849394561" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-pro-2019", "originalImageName": "refurb-mac-pro-2019", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G14GQLL/A/Refurbished-Mac-Pro-32GHz-16-core-Intel-Xeon-W-Radeon-Pro-W6800X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 6, "priceAsc": 132 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G14GQLL/A", "basePartNumber": "G14GQ", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G10MYLL/A", "sortOrder": 133, "filters": { "dimensions": { "dimensionCapacity": "4tb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "192gb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G10MYLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G10MY", "currentPrice": { "amount": "$10,789.00", "raw_amount": "10789.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac Pro 3.2GHz 16-core Intel Xeon W, Radeon Pro 580X", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-rack-2019?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1605114669000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1605114669000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-pro-rack-2019", "originalImageName": "refurb-mac-pro-rack-2019", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G10MYLL/A/Refurbished-Mac-Pro-32GHz-16-core-Intel-Xeon-W-Radeon-Pro-580X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 5, "priceAsc": 133 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G10MYLL/A", "basePartNumber": "G10MY", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G10RXLL/A", "sortOrder": 134, "filters": { "dimensions": { "dimensionCapacity": "4tb", "refurbClearModel": "macpro", "dimensionRelYear": "2019" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G10RXLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G10RX", "currentPrice": { "amount": "$26,769.00", "raw_amount": "26769.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac Pro 2.5GHz 28-core Intel Xeon W, Two Radeon Pro Vega II Duo", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-rack-2019?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1605114669000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1605114669000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-pro-rack-2019", "originalImageName": "refurb-mac-pro-rack-2019", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G10RXLL/A/Refurbished-Mac-Pro-25GHz-28-core-Intel-Xeon-W-Two-Radeon-Pro-Vega-II-Duo?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 4, "priceAsc": 134 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G10RXLL/A", "basePartNumber": "G10RX", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0ZKLLL/A", "sortOrder": 135, "filters": { "dimensions": { "dimensionCapacity": "1tb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "1_5tb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0ZKLLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0ZKL", "currentPrice": { "amount": "$41,649.00", "raw_amount": "41649.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac Pro 2.5GHz 28-core Intel Xeon W, Two Radeon Pro Vega II Duo, Apple Afterburner", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-2019?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1585849394561", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1585849394561" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-pro-2019", "originalImageName": "refurb-mac-pro-2019", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0ZKLLL/A/Refurbished-Mac-Pro-25GHz-28-core-Intel-Xeon-W-Two-Radeon-Pro-Vega-II-Duo-Apple-Afterburner?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 3, "priceAsc": 135 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0ZKLLL/A", "basePartNumber": "G0ZKL", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G0ZKMLL/A", "sortOrder": 136, "filters": { "dimensions": { "dimensionCapacity": "4tb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "1_5tb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G0ZKMLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G0ZKM", "currentPrice": { "amount": "$42,159.00", "raw_amount": "42159.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac Pro 2.5GHz 28-core Intel Xeon W, Two Radeon Pro Vega II Duo, Apple Afterburner", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-2019?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1585849394561", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1585849394561" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-pro-2019", "originalImageName": "refurb-mac-pro-2019", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G0ZKMLL/A/Refurbished-Mac-Pro-25GHz-28-core-Intel-Xeon-W-Two-Radeon-Pro-Vega-II-Duo-Apple-Afterburner?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 2, "priceAsc": 136 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G0ZKMLL/A", "basePartNumber": "G0ZKM", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }, { "partNumber": "G10TTLL/A", "sortOrder": 137, "filters": { "dimensions": { "dimensionCapacity": "256gb", "refurbClearModel": "macpro", "dimensionRelYear": "2019", "tsMemorySize": "1_5tb" } }, "price": { "priceFeeDisclaimer": "", "priceCurrency": "USD", "partNumber": "G10TTLL/A", "showItemPropPrice": true, "showItemPropAvailability": false, "showPromoAsIncludes": false, "showPayPal": false, "showDynamicFinancing": false, "chooseDefaultPurchaseOption": false, "refurbProduct": true, "basePartNumber": "G10TT", "currentPrice": { "amount": "$43,599.00", "raw_amount": "43599.00" }, "adjustedPrice": {} }, "title": "Refurbished Mac Pro 2.5GHz 28-core Intel Xeon W, Two Radeon Pro Vega II Duo, Apple Afterburner", "image": { "scaleFactor": "RETINA", "srcSet": { "src": "https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/refurb-mac-pro-rack-2019?wid=400&hei=400&fmt=jpeg&qlt=90&.v=1605114669000", "scaleParams1": "wid=200&hei=200&fmt=jpeg&qlt=95&.v=1605114669000" }, "attrs": "", "alt": "", "width": "200", "height": "200", "imageName": "refurb-mac-pro-rack-2019", "originalImageName": "refurb-mac-pro-rack-2019", "noImage": false, "deferSrc": false }, "lob": "mac", "productDetailsUrl": "/shop/product/G10TTLL/A/Refurbished-Mac-Pro-25GHz-28-core-Intel-Xeon-W-Two-Radeon-Pro-Vega-II-Duo-Apple-Afterburner?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810", "sort": { "priceDesc": 1, "priceAsc": 137 }, "omnitureModel": { "slotName": "", "featureName": "Refurb", "linkText": "AOS: home/refurbished/mac", "partNumber": "G10TTLL/A", "basePartNumber": "G10TT", "commitCodeId": 0, "customerCommitString": "Within 24 hours" } }], "dimensions": [{ "legend": "Models", "sortOrder": 0, "key": "refurbClearModel" }, { "legend": "Sizes", "sortOrder": 1, "key": "dimensionScreensize" }, { "legend": "Release Year", "sortOrder": 2, "key": "dimensionRelYear" }, { "legend": "Finish", "sortOrder": 3, "key": "dimensionColor" }, { "legend": "Memory", "sortOrder": 4, "key": "tsMemorySize" }, { "legend": "Capacity", "sortOrder": 5, "key": "dimensionCapacity" }], "staticAssets": {}, "sortData": { "data": { "options": [{ "text": "Price: Low to High", "value": "priceAsc", "selected": true }, { "text": "Price: High to Low", "value": "priceDesc", "selected": false }], "key": "sort", "legend": "" } }, "selectedGridFilters": null };
+            </script>
+
+
+
+
+            <style>
+                .rf-refurb-category-grid-no-js {
+                    display: none;
+                }
+
+                .nojs .rf-refurb-category-grid-no-js {
+                    display: block;
+                }
+            </style>
+            <div class="rf-refurb-category-grid-no-js">
+                <ul>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/FGNR3LL/A/refurbished-mac-mini-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini Apple M1 Chip with 8‑Core CPU and 8‑Core GPU</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $589.00
+                        </div>
+                        <span class="as-price-previousprice">
+                            <span class="was-text">Was</span> $699.00
+                        </span>
+                        <span class="as-producttile-savingsprice">
+                            Save $110.00
+                        </span>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/FXNF2LL/A/Refurbished-Mac-mini-36GHz-quad-core-Intel-Core-i3-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini 3.6GHz quad-core Intel Core i3 - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $679.00
+                        </div>
+                        <span class="as-price-previousprice">
+                            <span class="was-text">Was</span> $799.00
+                        </span>
+                        <span class="as-producttile-savingsprice">
+                            Save $120.00
+                        </span>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/FGNT3LL/A/refurbished-mac-mini-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini Apple M1 Chip with 8‑Core CPU and 8‑Core GPU</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $759.00
+                        </div>
+                        <span class="as-price-previousprice">
+                            <span class="was-text">Was</span> $899.00
+                        </span>
+                        <span class="as-producttile-savingsprice">
+                            Save $140.00
+                        </span>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/FGND3LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8%E2%80%91core-cpu-and-7%E2%80%91core-gpu-gold?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 7‑Core GPU - Gold</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $849.00
+                        </div>
+                        <span class="as-price-previousprice">
+                            <span class="was-text">Was</span> $999.00
+                        </span>
+                        <span class="as-producttile-savingsprice">
+                            Save $150.00
+                        </span>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/FGN93LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8%E2%80%91core-cpu-and-7%E2%80%91core-gpu-silver?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 7‑Core GPU - Silver</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $849.00
+                        </div>
+                        <span class="as-price-previousprice">
+                            <span class="was-text">Was</span> $999.00
+                        </span>
+                        <span class="as-producttile-savingsprice">
+                            Save $150.00
+                        </span>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/FGN63LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8%E2%80%91core-cpu-and-7%E2%80%91core-gpu-space-gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 7‑Core GPU - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $849.00
+                        </div>
+                        <span class="as-price-previousprice">
+                            <span class="was-text">Was</span> $999.00
+                        </span>
+                        <span class="as-producttile-savingsprice">
+                            Save $150.00
+                        </span>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/FRT32LL/A/Refurbished-215-inch-iMac-36GHz-quad-core-Intel-Core-i3-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 3.6GHz quad-core Intel Core i3 with Retina 4K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $899.00
+                        </div>
+                        <span class="as-price-previousprice">
+                            <span class="was-text">Was</span> $1,249.00
+                        </span>
+                        <span class="as-producttile-savingsprice">
+                            Save $350.00
+                        </span>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0TH0LL/A/Refurbished-215-inch-iMac-23GHz-dual-core-Intel-Core-i5?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 2.3GHz dual-core Intel Core i5</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $929.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G12P1LL/A/refurbished-mac-mini-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini Apple M1 Chip with 8‑Core CPU and 8‑Core GPU</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $929.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0TH1LL/A/Refurbished-215-inch-iMac-23GHz-dual-core-Intel-Core-i5?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 2.3GHz dual-core Intel Core i5</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $929.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/FXNG2LL/A/Refurbished-Mac-mini-30GHz-6-core-Intel-Core-i5-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini 3.0GHz 6-core Intel Core i5 - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $929.00
+                        </div>
+                        <span class="as-price-previousprice">
+                            <span class="was-text">Was</span> $1,099.00
+                        </span>
+                        <span class="as-producttile-savingsprice">
+                            Save $170.00
+                        </span>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/FYD82LL/A/refurbished-133-inch-macbook-pro-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu-space-gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                13.3-inch MacBook Pro Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,059.00
+                        </div>
+                        <span class="as-price-previousprice">
+                            <span class="was-text">Was</span> $1,249.00
+                        </span>
+                        <span class="as-producttile-savingsprice">
+                            Save $190.00
+                        </span>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/FGNA3LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu-silver?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Silver</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,059.00
+                        </div>
+                        <span class="as-price-previousprice">
+                            <span class="was-text">Was</span> $1,149.00
+                        </span>
+                        <span class="as-producttile-savingsprice">
+                            Save $90.00
+                        </span>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/FGN73LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu-space-gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,059.00
+                        </div>
+                        <span class="as-price-previousprice">
+                            <span class="was-text">Was</span> $1,149.00
+                        </span>
+                        <span class="as-producttile-savingsprice">
+                            Save $90.00
+                        </span>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0TH3LL/A/refurbished-215-inch-imac-23ghz-dual-core-intel-core-i5?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 2.3GHz dual-core Intel Core i5</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,059.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/FYDA2LL/A/refurbished-133-inch-macbook-pro-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu-silver?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                13.3-inch MacBook Pro Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Silver</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,059.00
+                        </div>
+                        <span class="as-price-previousprice">
+                            <span class="was-text">Was</span> $1,249.00
+                        </span>
+                        <span class="as-producttile-savingsprice">
+                            Save $190.00
+                        </span>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/FGNE3LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu-gold?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Gold</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,059.00
+                        </div>
+                        <span class="as-price-previousprice">
+                            <span class="was-text">Was</span> $1,149.00
+                        </span>
+                        <span class="as-producttile-savingsprice">
+                            Save $90.00
+                        </span>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G12P7LL/A/refurbished-mac-mini-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini Apple M1 Chip with 8‑Core CPU and 8‑Core GPU</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,099.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0TH2LL/A/Refurbished-215-inch-iMac-23GHz-dual-core-Intel-Core-i5?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 2.3GHz dual-core Intel Core i5</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,099.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0ZTPLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,099.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0ZT5LL/A/Refurbished-Mac-mini-30GHz-6-core-Intel-Core-i5-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini 3.0GHz 6-core Intel Core i5 - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,099.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0TH4LL/A/Refurbished-215-inch-iMac-23GHz-dual-core-Intel-Core-i5?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 2.3GHz dual-core Intel Core i5</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,099.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0VX1LL/A/Refurbished-215-inch-iMac-36GHz-quad-core-Intel-Core-i3-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 3.6GHz quad-core Intel Core i3 with Retina 4K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,099.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G12P8LL/A/Refurbished-Mac-mini-Apple-M1-Chip-with-8%E2%80%91Core-CPU-and-8%E2%80%91Core-GPU-10GB-Ethernet?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini Apple M1 Chip with 8‑Core CPU and 8‑Core GPU, 10GB Ethernet</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,189.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/FYDC2LL/A/refurbished-133-inch-macbook-pro-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu-silver?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                13.3-inch MacBook Pro Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Silver</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,229.00
+                        </div>
+                        <span class="as-price-previousprice">
+                            <span class="was-text">Was</span> $1,449.00
+                        </span>
+                        <span class="as-producttile-savingsprice">
+                            Save $220.00
+                        </span>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G1252LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu-space-gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,229.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/FYD92LL/A/refurbished-133-inch-macbook-pro-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu-space-gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                13.3-inch MacBook Pro Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,229.00
+                        </div>
+                        <span class="as-price-previousprice">
+                            <span class="was-text">Was</span> $1,449.00
+                        </span>
+                        <span class="as-producttile-savingsprice">
+                            Save $220.00
+                        </span>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G11B0LL/A/refurbished-133-inch-macbook-pro-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu-space-gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                13.3-inch MacBook Pro Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,229.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0VX6LL/A/Refurbished-215-inch-iMac-36GHz-quad-core-Intel-Core-i3-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 3.6GHz quad-core Intel Core i3 with Retina 4K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,269.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0ZT7LL/A/Refurbished-Mac-mini-30GHz-6-core-Intel-Core-i5-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini 3.0GHz 6-core Intel Core i5 - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,269.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0VY1LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,269.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G1253LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu-space-gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,399.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G12B3LL/A/refurbished-133-inch-macbook-air-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu-gold?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                13.3-inch MacBook Air Apple M1 Chip with 8‑Core CPU and 8‑Core GPU - Gold</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,399.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0W18LL/A/Refurbished-Mac-mini-36GHz-quad-core-Intel-Core-i3-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini 3.6GHz quad-core Intel Core i3 - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,439.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0W2ULL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,439.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0VX3LL/A/Refurbished-215-inch-iMac-36GHz-quad-core-Intel-Core-i3-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 3.6GHz quad-core Intel Core i3 with Retina 4K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,439.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0ZTXLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,439.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0VYRLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,439.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0VY9LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,439.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G12P9LL/A/refurbished-mac-mini-apple-m1-chip-with-8%E2%80%91core-cpu-and-8%E2%80%91core-gpu?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini Apple M1 Chip with 8‑Core CPU and 8‑Core GPU</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,439.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0VY3LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,439.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G12PALL/A/Refurbished-Mac-mini-Apple-M1-Chip-with-8%E2%80%91Core-CPU-and-8%E2%80%91Core-GPU-10GB-Ethernet?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini Apple M1 Chip with 8‑Core CPU and 8‑Core GPU, 10GB Ethernet</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,529.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0VY2LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display-and-Radeon-Pro-Vega-20?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display and Radeon Pro Vega
+                                20</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,569.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0VY0LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display-and-Radeon-Pro-Vega-20?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display and Radeon Pro Vega
+                                20</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,569.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0VY5LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,609.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G11L1LL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,609.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0VYBLL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,609.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/GMW2LLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,609.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0VYXLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,609.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0VYZLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,609.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0VYTLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,609.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0VYQLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display-and-Radeon-Pro-Vega-20?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display and Radeon Pro Vega
+                                20</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,739.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G11L3LL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,779.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0VQ3LL/A/Refurbished-27-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,779.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0W2YLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,779.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0VYDLL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,779.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/FJMV3LL/A/refurbished-mac-studio-apple-m1-max-chip-with-10%E2%80%91core-cpu-and-24%E2%80%91core-gpu?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac Studio Apple M1 Max Chip with 10‑Core CPU and 24‑Core GPU</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,799.00
+                        </div>
+                        <span class="as-price-previousprice">
+                            <span class="was-text">Was</span> $1,999.00
+                        </span>
+                        <span class="as-producttile-savingsprice">
+                            Save $200.00
+                        </span>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/GMW2ALL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,869.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0VR4LL/A/Refurbished-27-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac 3.1GHz 6-core Intel Core i5 with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,869.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0VY6LL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display-and-Radeon-Pro-Vega-20?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display and Radeon Pro Vega
+                                20</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,909.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0VYCLL/A/Refurbished-215-inch-iMac-30GHz-6-core-Intel-Core-i5-with-Retina-4K-display-and-Radeon-Pro-Vega-20?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 3.0GHz 6-core Intel Core i5 with Retina 4K display and Radeon Pro Vega
+                                20</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,909.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/GMVY3LL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,949.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G14J0LL/A/refurbished-mac-studio-apple-m1-max-chip-with-10%E2%80%91core-cpu-and-24%E2%80%91core-gpu?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac Studio Apple M1 Max Chip with 10‑Core CPU and 24‑Core GPU</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,979.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G14J9LL/A/refurbished-mac-studio-apple-m1-max-chip-with-10%E2%80%91core-cpu-and-32%E2%80%91core-gpu?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac Studio Apple M1 Max Chip with 10‑Core CPU and 32‑Core GPU</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $1,979.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G14JALL/A/refurbished-mac-studio-apple-m1-max-chip-with-10%E2%80%91core-cpu-and-32%E2%80%91core-gpu?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac Studio Apple M1 Max Chip with 10‑Core CPU and 32‑Core GPU</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $2,159.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/GMW2DLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $2,209.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/GMVY4LL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display-and-Radeon-Pro-Vega-20?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display and Radeon Pro Vega
+                                20</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $2,249.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/FK1E3LL/A/refurbished-16-inch-macbook-pro-apple-m1-pro-chip-with-10%E2%80%91core-cpu-and-16%E2%80%91core-gpu-silver?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                16-inch MacBook Pro Apple M1 Pro Chip with 10‑Core CPU and 16‑Core GPU - Silver</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $2,249.00
+                        </div>
+                        <span class="as-price-previousprice">
+                            <span class="was-text">Was</span> $2,499.00
+                        </span>
+                        <span class="as-producttile-savingsprice">
+                            Save $250.00
+                        </span>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/FKGT3LL/A/refurbished-14-inch-macbook-pro-apple-m1-pro-chip-with-10%E2%80%91core-cpu-and-16%E2%80%91core-gpu-silver?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                14-inch MacBook Pro Apple M1 Pro Chip with 10‑Core CPU and 16‑Core GPU - Silver</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $2,249.00
+                        </div>
+                        <span class="as-price-previousprice">
+                            <span class="was-text">Was</span> $2,499.00
+                        </span>
+                        <span class="as-producttile-savingsprice">
+                            Save $250.00
+                        </span>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/FKGQ3LL/A/refurbished-14-inch-macbook-pro-apple-m1-pro-chip-with-10%E2%80%91core-cpu-and-16%E2%80%91core-gpu-space-gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                14-inch MacBook Pro Apple M1 Pro Chip with 10‑Core CPU and 16‑Core GPU - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $2,249.00
+                        </div>
+                        <span class="as-price-previousprice">
+                            <span class="was-text">Was</span> $2,499.00
+                        </span>
+                        <span class="as-producttile-savingsprice">
+                            Save $250.00
+                        </span>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/FK183LL/A/refurbished-16-inch-macbook-pro-apple-m1-pro-chip-with-10%E2%80%91core-cpu-and-16%E2%80%91core-gpu-space-gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                16-inch MacBook Pro Apple M1 Pro Chip with 10‑Core CPU and 16‑Core GPU - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $2,249.00
+                        </div>
+                        <span class="as-price-previousprice">
+                            <span class="was-text">Was</span> $2,499.00
+                        </span>
+                        <span class="as-producttile-savingsprice">
+                            Save $250.00
+                        </span>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/FK1F3LL/A/refurbished-16-inch-macbook-pro-apple-m1-pro-chip-with-10%E2%80%91core-cpu-and-16%E2%80%91core-gpu-silver?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                16-inch MacBook Pro Apple M1 Pro Chip with 10‑Core CPU and 16‑Core GPU - Silver</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $2,429.00
+                        </div>
+                        <span class="as-price-previousprice">
+                            <span class="was-text">Was</span> $2,699.00
+                        </span>
+                        <span class="as-producttile-savingsprice">
+                            Save $270.00
+                        </span>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G11LBLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $2,459.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/GMW22LL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $2,459.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/GMW2ELL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini 3.2GHz 6-core Intel Core i7 - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $2,549.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G11LCLL/A/Refurbished-Mac-mini-32GHz-6-core-Intel-Core-i7-Space-Gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac mini 3.2GHz 6-core Intel Core i7, 10GB Ethernet - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $2,549.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/GMVYCLL/A/Refurbished-215-inch-iMac-32GHz-6-core-Intel-Core-i7-with-Retina-4K-display-and-Radeon-Pro-Vega-20?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                21.5-inch iMac 3.2GHz 6-core Intel Core i7 with Retina 4K display and Radeon Pro Vega
+                                20</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $2,589.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/FK1H3LL/A/refurbished-16-inch-macbook-pro-apple-m1-max-chip-with-10%E2%80%91core-cpu-and-32%E2%80%91core-gpu-silver?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                16-inch MacBook Pro Apple M1 Max Chip with 10‑Core CPU and 32‑Core GPU - Silver</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $3,149.00
+                        </div>
+                        <span class="as-price-previousprice">
+                            <span class="was-text">Was</span> $3,499.00
+                        </span>
+                        <span class="as-producttile-savingsprice">
+                            Save $350.00
+                        </span>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0ZV2LL/A/refurbished-27-inch-imac-31GHz-6-core-Intel-Core-i5-with-retina-5k-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac 3.1GHz 6-core Intel Core i5 with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $3,179.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0ZV7LL/A/Refurbished-27-inch-iMac-31GHz-6-core-Intel-Core-i5-with-Retina-5K-display-10GB-Ethernet?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac 3.1GHz 6-core Intel Core i5 with Retina 5K display, 10GB Ethernet</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $3,249.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/FQ2Y2LL/A/Refurbished-27-inch-iMac-Pro-32GHz-8-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 3.2GHz 8-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $3,249.00
+                        </div>
+                        <span class="as-price-previousprice">
+                            <span class="was-text">Was</span> $4,499.00
+                        </span>
+                        <span class="as-producttile-savingsprice">
+                            Save $1,250.00
+                        </span>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G15HKLL/A/refurbished-14-inch-macbook-pro-apple-m1-max-chip-with-10%E2%80%91core-cpu-and-32%E2%80%91core-gpu-space-gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                14-inch MacBook Pro Apple M1 Max Chip with 10‑Core CPU and 32‑Core GPU - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $3,329.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G16P9LL/A/refurbished-27-inch-imac-38ghz-8-core-intel-core-i7-with-retina-5k-display-10gb-ethernet?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac 3.8GHz 8-core Intel Core i7 with Retina 5K display, 10GB Ethernet</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $3,679.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G15HLLL/A/refurbished-14-inch-macbook-pro-apple-m1-max-chip-with-10%E2%80%91core-cpu-and-32%E2%80%91core-gpu-space-gray?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                14-inch MacBook Pro Apple M1 Max Chip with 10‑Core CPU and 32‑Core GPU - Space Gray</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $3,689.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G16P5LL/A/refurbished-27-inch-imac-36ghz-10-core-intel-core-i9-with-retina-5k-display-10gb-ethernet?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac 3.6GHz 10-core Intel Core i9 with Retina 5K display, 10GB Ethernet</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $3,759.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G11P5LL/A/refurbished-27-inch-imac-36ghz-10-core-intel-core-i9-with-retina-5k-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac 3.6GHz 10-core Intel Core i9 with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $3,819.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0URYLL/A/Refurbished-27-inch-iMac-Pro-32GHz-8-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 3.2GHz 8-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $4,159.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0URNLL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $4,249.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0URKLL/A/Refurbished-27-inch-iMac-Pro-32GHz-8-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 3.2GHz 8-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $4,289.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G11QULL/A/Refurbished-27-inch-iMac-36GHz-10-core-Intel-Core-i9-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac 3.6GHz 10-core Intel Core i9 with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $4,329.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G11PELL/A/Refurbished-27-inch-iMac-36GHz-10-core-Intel-Core-i9-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac 3.6GHz 10-core Intel Core i9 with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $4,479.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0UR3LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $4,589.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0UR5LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $4,589.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0UR0LL/A/Refurbished-27-inch-iMac-Pro-32GHz-8-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 3.2GHz 8-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $4,629.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0URXLL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $4,719.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0UR7LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $4,929.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0URQLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $4,929.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0UR4LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $5,059.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0UR6LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $5,059.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/GPURYLL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $5,099.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/GNURELL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display-and-Radeon-Pro-Vega-64X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display and Radeon Pro Vega
+                                64X</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $5,179.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0W30LL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac Pro 3.5GHz 8-core Intel Xeon W, Radeon Pro 580X</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $5,179.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/GMURKLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $5,269.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/GMURJLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $5,269.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/GMURHLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $5,399.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0UR8LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $5,399.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0UR9LL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $5,439.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0URGLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $5,609.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G10K0LL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac Pro 3.5GHz 8-core Intel Xeon W, Radeon Pro 580X</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $5,609.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/GMURLLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $5,739.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0URALL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $5,909.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0URDLL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 2.3GHz 18-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $5,949.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G11R0LL/A/Refurbished-27-inch-iMac-36GHz-10-core-Intel-Core-i9-with-Retina-5K-display-10GB-Ethernet?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac 3.6GHz 10-core Intel Core i9 with Retina 5K display, 10GB Ethernet</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $5,989.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G1434LL/A/refurbished-mac-pro-35ghz-8-core-intel-xeon-w-radeon-pro-w5700x?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac Pro 3.5GHz 8-core Intel Xeon W, Radeon Pro W5700X</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $6,029.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0URHLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $6,079.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G10K2LL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac Pro 3.5GHz 8-core Intel Xeon W, Radeon Pro 580X</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $6,289.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0URBLL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $6,289.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/GMURDLL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 2.3GHz 18-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $6,289.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0URSLL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 2.3GHz 18-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $6,419.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0W36LL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac Pro 3.5GHz 8-core Intel Xeon W, Radeon Pro 580X</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $6,459.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0URCLL/A/Refurbished-27-inch-iMac-Pro-30GHz-10-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 3.0GHz 10-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $6,759.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/GNURZLL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display-and-Radeon-Pro-Vega-64X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 2.3GHz 18-core Intel Xeon W with Retina 5K display and Radeon Pro Vega
+                                64X</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $6,879.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/GMURFLL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 2.3GHz 18-core Intel Xeon W with Retina 5K display</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $7,309.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G10LFLL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac Pro 3.3GHz 12-core Intel Xeon W, Radeon Pro 580X</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $7,389.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G143FLL/A/Refurbished-Mac-Pro-33GHz-12-core-Intel-Xeon-W-Radeon-Pro-W5700X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac Pro 3.3GHz 12-core Intel Xeon W, Radeon Pro W5700X</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $7,479.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G10LGLL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Radeon-Pro-580X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac Pro 3.3GHz 12-core Intel Xeon W, Radeon Pro 580X</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $7,729.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G10MPLL/A/Refurbished-Mac-Pro-32GHz-16-core-Intel-Xeon-W-Radeon-Pro-580X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac Pro 3.2GHz 16-core Intel Xeon W, Radeon Pro 580X</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $7,989.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/GPURMLL/A/Refurbished-27-inch-iMac-Pro-25GHz-14-core-Intel-Xeon-W-with-Retina-5K-display-and-Radeon-Pro-Vega-64X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 2.5GHz 14-core Intel Xeon W with Retina 5K display and Radeon Pro Vega
+                                64X</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $8,069.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0ZDFLL/A/Refurbished-Mac-Pro-32GHz-16-core-Intel-Xeon-W-Radeon-Pro-580X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac Pro 3.2GHz 16-core Intel Xeon W, Radeon Pro 580X</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $8,159.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/GPUR2LL/A/Refurbished-27-inch-iMac-Pro-23GHz-18-core-Intel-Xeon-W-with-Retina-5K-display-and-Radeon-Pro-Vega-64X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                27-inch iMac Pro 2.3GHz 18-core Intel Xeon W with Retina 5K display and Radeon Pro Vega
+                                64X</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $8,239.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G143ULL/A/Refurbished-Mac-Pro-33GHz-12-core-Intel-Xeon-W-Radeon-Pro-Vega-II?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac Pro 3.3GHz 12-core Intel Xeon W, Radeon Pro Vega II</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $8,579.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G10TWLL/A/Refurbished-Mac-Pro-35GHz-8-core-Intel-Xeon-W-Two-Radeon-Pro-W5700X-Apple-Afterburner?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac Pro 3.5GHz 8-core Intel Xeon W, Two Radeon Pro W5700X, Apple Afterburner</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $9,179.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G14GQLL/A/Refurbished-Mac-Pro-32GHz-16-core-Intel-Xeon-W-Radeon-Pro-W6800X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac Pro 3.2GHz 16-core Intel Xeon W, Radeon Pro W6800X</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $9,429.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G10MYLL/A/Refurbished-Mac-Pro-32GHz-16-core-Intel-Xeon-W-Radeon-Pro-580X?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac Pro 3.2GHz 16-core Intel Xeon W, Radeon Pro 580X</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $10,789.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G10RXLL/A/Refurbished-Mac-Pro-25GHz-28-core-Intel-Xeon-W-Two-Radeon-Pro-Vega-II-Duo?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac Pro 2.5GHz 28-core Intel Xeon W, Two Radeon Pro Vega II Duo</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $26,769.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0ZKLLL/A/Refurbished-Mac-Pro-25GHz-28-core-Intel-Xeon-W-Two-Radeon-Pro-Vega-II-Duo-Apple-Afterburner?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac Pro 2.5GHz 28-core Intel Xeon W, Two Radeon Pro Vega II Duo, Apple Afterburner</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $41,649.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G0ZKMLL/A/Refurbished-Mac-Pro-25GHz-28-core-Intel-Xeon-W-Two-Radeon-Pro-Vega-II-Duo-Apple-Afterburner?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac Pro 2.5GHz 28-core Intel Xeon W, Two Radeon Pro Vega II Duo, Apple Afterburner</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $42,159.00
+                        </div>
+                    </li>
+                    <li>
+                        <h3>
+                            <a
+                                href="/shop/product/G10TTLL/A/Refurbished-Mac-Pro-25GHz-28-core-Intel-Xeon-W-Two-Radeon-Pro-Vega-II-Duo-Apple-Afterburner?fnode=475eb97c9e9d3dcf836de247cc53b90afba825fd3d02d1011f734588e504a2b926e2421155a1f05fc981bebe832e2d6018c9a6fe63804d43535f4665d495879b71e39d07881a2911e6acc1be3596b810">Refurbished
+                                Mac Pro 2.5GHz 28-core Intel Xeon W, Two Radeon Pro Vega II Duo, Apple Afterburner</a>
+                        </h3>
+                        <div class="as-price-currentprice as-producttile-currentprice">
+                            $43,599.00
+                        </div>
+                    </li>
+                </ul>
+            </div>
+
+
+
+
+
+
+
+
+
+
+
+            <div class="as-footnotes buystrip buystrip-background">
+                <div class="buystrip-content">
+                    <section class="buystrip-items">
+                        <section class="buystrip-item">
+
+                            <div class="buystrip-item-content  superlink">
+                                <figure class="buystrip-item-icon">
+                                    <img src="https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/icon-why-refurb-grey-201811?wid=95&amp;hei=112&amp;fmt=png-alpha&amp;.v=1586396517342"
+                                        alt="" width="47" height="56"
+                                        data-scale-params-1="wid=47&amp;hei=56&amp;fmt=png-alpha&amp;.v=1586396517342"
+                                        data-scale-initial="2" class="ir" />
+
+                                </figure>
+                                <h3 class="buystrip-item-title">Why Refurbished</h3>
+                                <p class="buystrip-item-copy">Every product undergoes a rigorous certification process.
+                                </p>
+                                <p class="buystrip-item-cta"><a href="/shop/refurbished/about" data-slot-name="main10"
+                                        data-feature-name="Astro Link" data-display-name="AOS: home/refurbished/about"
+                                        class="more">Learn more<span class="visuallyhidden"> Why Refurbished</span></a>
+                                </p>
+                            </div>
+
+                        </section>
+
+                        <section class="buystrip-item">
+
+                            <div class="buystrip-item-content  superlink">
+                                <figure class="buystrip-item-icon">
+                                    <img src="https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/icon-apple-care-grey-201811?wid=58&amp;hei=112&amp;fmt=png-alpha&amp;.v=1586396517300"
+                                        alt="" width="29" height="56"
+                                        data-scale-params-1="wid=29&amp;hei=56&amp;fmt=png-alpha&amp;.v=1586396517300"
+                                        data-scale-initial="2" class="ir" />
+
+                                </figure>
+                                <h3 class="buystrip-item-title">AppleCare</h3>
+                                <p class="buystrip-item-copy">Service and support for your refurbished Apple products.
+                                </p>
+                                <p class="buystrip-item-cta"><a href="https://www.apple.com/support/products"
+                                        data-slot-name="main10" data-feature-name="Astro Link"
+                                        data-display-name="AOS: support/products" class="more">Learn more<span
+                                            class="visuallyhidden"> AppleCare</span></a></p>
+                            </div>
+
+                        </section>
+
+                        <section class="buystrip-item">
+
+                            <div class="buystrip-item-content  superlink">
+                                <figure class="buystrip-item-icon">
+                                    <img src="https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/icon-shipping-grey-2017?wid=89&amp;hei=112&amp;fmt=png-alpha&amp;.v=1624381070000"
+                                        alt="" width="44" height="56"
+                                        data-scale-params-1="wid=44&amp;hei=56&amp;fmt=png-alpha&amp;.v=1624381070000"
+                                        data-scale-initial="2" class="ir" />
+
+                                </figure>
+                                <h3 class="buystrip-item-title">Free next-day delivery</h3>
+                                <p class="buystrip-item-copy dd-expand-large-2">On select in-stock Apple products
+                                    ordered by 5:00 p.m.</p>
+                                <p class="buystrip-item-cta"><a href="/shop/campaigns/shipping-and-returns"
+                                        data-slot-name="main10" data-feature-name="Astro Link"
+                                        data-display-name="AOS: campaigns/shipping_and_returns" class="more">Learn
+                                        more<span class="visuallyhidden"> Free next-day delivery</span></a></p>
+                            </div>
+
+                        </section>
+
+                    </section>
+                </div>
+            </div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        </div>
+
+        <div class="as-footnotes " data-nosnippet>
+            <div class="as-footnotes-content">
+                <div class="as-footnotes-sosumi">
+
+
+
+
+
+
+                    <div class="footnotes" role="list" aria-label="footnotes">
+
+
+
+                    </div>
+
+                    †† We approximate your location from your internet IP address by matching it to a geographic region
+                    or from the location entered during your previous visit to Apple.
+                </div>
+            </div>
+        </div>
+
+        <footer class="as-globalfooter no-js" id="apple-footer">
+            <div class="as-globalfooter-content">
+
+                <nav class="as-globalfooter-breadcrumbs" aria-label="Breadcrumbs" role="navigation">
+                    <a href="https://www.apple.com/" data-feature-name="Breadcrumb" data-display-name="Apple"
+                        class="as-globalfooter-breadcrumbs-home" data-autom="footer"> <span
+                            class="as-globalfooter-breadcrumbs-home-icon" aria-hidden="true"></span>
+                        <span class="as-globalfooter-breadcrumbs-home-label">Apple</span>
+                    </a>
+                    <div class="as-globalfooter-breadcrumbs-path">
+                        <ol class="as-globalfooter-breadcrumbs-list" typeof="BreadcrumbList">
+                            <li class="as-globalfooter-breadcrumbs-item" property="itemListElement" typeof="ListItem">
+
+                                <span property="item">Refurbished Mac</span>
+                                <meta property="position" content="1" />
+                            </li>
+                        </ol>
+                    </div>
+                </nav>
+
+
+                <nav role="navigation" aria-label="More Apple Store Links"
+                    class="as-globalfooter-directory with-5-columns">
+                    <div class="as-globalfooter-directory-column">
+                        <input class="as-globalfooter-directory-column-section-state" type="checkbox"
+                            id="as-globalfooter-state-section-one" />
+                        <div class="as-globalfooter-directory-column-section">
+                            <label class="as-globalfooter-directory-column-section-label"
+                                for="as-globalfooter-state-section-one" data-asext-evar="eVar6"
+                                data-asext-feature="footer" data-asext-part="Shop and Learn" data-asext-action="expand"
+                                data-asext-action-toggle="collapse">
+                                <h3 class="as-globalfooter-directory-column-section-title">Shop and Learn</h3>
+                            </label>
+                            <a href="#as-globalfooter-state-section-one"
+                                class="as-globalfooter-directory-column-section-anchor as-globalfooter-directory-column-section-anchor-open"><span
+                                    class="as-globalfooter-directory-column-section-anchor-label">Open
+                                    Menusection-one</span></a>
+                            <a href="#"
+                                class="as-globalfooter-direcotry-column-section-anchor as-globalfooter-directory-column-section-anchor-close"><span
+                                    class="as-globalfooter-directory-column-section-anchor-label">Close
+                                    Menusection-one</span></a>
+                            <ul class="as-globalfooter-directory-column-section-list">
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/mac/" data-slot-name="section1"
+                                        data-feature-name="Footer Navigation" data-display-name="Mac"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Mac-footer-link"> Mac
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/ipad/" data-slot-name="section1"
+                                        data-feature-name="Footer Navigation" data-display-name="iPad"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="iPad-footer-link"> iPad
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/iphone/" data-slot-name="section1"
+                                        data-feature-name="Footer Navigation" data-display-name="iPhone"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="iPhone-footer-link"> iPhone
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/watch/" data-slot-name="section1"
+                                        data-feature-name="Footer Navigation" data-display-name="Watch"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Watch-footer-link"> Watch
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/airpods/" data-slot-name="section1"
+                                        data-feature-name="Footer Navigation" data-display-name="AirPods"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="AirPods-footer-link"> AirPods
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/tv/" data-slot-name="section1"
+                                        data-feature-name="Footer Navigation" data-display-name="TV &amp; Home"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="TV & Home-footer-link"> TV & Home
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/airtag/" data-slot-name="section1"
+                                        data-feature-name="Footer Navigation" data-display-name="AirTag"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="AirTag-footer-link"> AirTag
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="/shop/accessories/all" data-slot-name="section1"
+                                        data-feature-name="Footer Navigation" data-display-name="Accessories"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Accessories-footer-link"> Accessories
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="/shop/gift-cards" data-slot-name="section1"
+                                        data-feature-name="Footer Navigation" data-display-name="Gift Cards"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Gift Cards-footer-link"> Gift Cards
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="as-globalfooter-directory-column">
+                        <input class="as-globalfooter-directory-column-section-state" type="checkbox"
+                            id="as-globalfooter-state-section-two-0" />
+                        <div class="as-globalfooter-directory-column-section">
+                            <label class="as-globalfooter-directory-column-section-label"
+                                for="as-globalfooter-state-section-two-0" data-asext-evar="eVar6"
+                                data-asext-feature="footer" data-asext-part="Services" data-asext-action="expand"
+                                data-asext-action-toggle="collapse">
+                                <h3 class="as-globalfooter-directory-column-section-title">Services</h3>
+                            </label>
+                            <a href="#as-globalfooter-state-section-two-0"
+                                class="as-globalfooter-directory-column-section-anchor as-globalfooter-directory-column-section-anchor-open"><span
+                                    class="as-globalfooter-directory-column-section-anchor-label">Open
+                                    Menusection-two-0</span></a>
+                            <a href="#"
+                                class="as-globalfooter-direcotry-column-section-anchor as-globalfooter-directory-column-section-anchor-close"><span
+                                    class="as-globalfooter-directory-column-section-anchor-label">Close
+                                    Menusection-two-0</span></a>
+                            <ul class="as-globalfooter-directory-column-section-list">
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/apple-music/" data-slot-name="section2"
+                                        data-feature-name="Footer Navigation" data-display-name="Apple Music"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Apple Music-footer-link"> Apple Music
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/apple-tv-plus/" data-slot-name="section2"
+                                        data-feature-name="Footer Navigation" data-display-name="Apple TV+"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Apple TV+-footer-link"> Apple TV+
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/apple-fitness-plus/" data-slot-name="section2"
+                                        data-feature-name="Footer Navigation" data-display-name="Apple Fitness+"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Apple Fitness+-footer-link"> Apple Fitness+
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/apple-news/" data-slot-name="section2"
+                                        data-feature-name="Footer Navigation" data-display-name="Apple News+ "
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Apple News+ -footer-link"> Apple News+
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/apple-arcade/" data-slot-name="section2"
+                                        data-feature-name="Footer Navigation" data-display-name="Apple Arcade"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Apple Arcade-footer-link"> Apple Arcade
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/icloud/" data-slot-name="section2"
+                                        data-feature-name="Footer Navigation" data-display-name="iCloud+"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="iCloud+-footer-link"> iCloud+
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/apple-one/" data-slot-name="section2"
+                                        data-feature-name="Footer Navigation" data-display-name="Apple One"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Apple One-footer-link"> Apple One
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/apple-card/" data-slot-name="section2"
+                                        data-feature-name="Footer Navigation" data-display-name="Apple Card"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Apple Card-footer-link"> Apple Card
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/apple-books/" data-slot-name="section2"
+                                        data-feature-name="Footer Navigation" data-display-name="Apple Books"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Apple Books-footer-link"> Apple Books
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/apple-podcasts/" data-slot-name="section2"
+                                        data-feature-name="Footer Navigation" data-display-name="Apple Podcasts"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Apple Podcasts-footer-link"> Apple Podcasts
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/app-store/" data-slot-name="section2"
+                                        data-feature-name="Footer Navigation" data-display-name="App Store"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="App Store-footer-link"> App Store
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                        <input class="as-globalfooter-directory-column-section-state" type="checkbox"
+                            id="as-globalfooter-state-section-two-1" />
+                        <div class="as-globalfooter-directory-column-section">
+                            <label class="as-globalfooter-directory-column-section-label"
+                                for="as-globalfooter-state-section-two-1" data-asext-evar="eVar6"
+                                data-asext-feature="footer" data-asext-part="Account" data-asext-action="expand"
+                                data-asext-action-toggle="collapse">
+                                <h3 class="as-globalfooter-directory-column-section-title">Account</h3>
+                            </label>
+                            <a href="#as-globalfooter-state-section-two-1"
+                                class="as-globalfooter-directory-column-section-anchor as-globalfooter-directory-column-section-anchor-open"><span
+                                    class="as-globalfooter-directory-column-section-anchor-label">Open
+                                    Menusection-two-1</span></a>
+                            <a href="#"
+                                class="as-globalfooter-direcotry-column-section-anchor as-globalfooter-directory-column-section-anchor-close"><span
+                                    class="as-globalfooter-directory-column-section-anchor-label">Close
+                                    Menusection-two-1</span></a>
+                            <ul class="as-globalfooter-directory-column-section-list">
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://appleid.apple.com" data-slot-name="section2"
+                                        data-feature-name="Footer Navigation" data-display-name="Manage Your Apple ID"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Manage Your Apple ID-footer-link"> Manage Your Apple ID
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://secure.store.apple.com/shop/account/home" data-slot-name="section2"
+                                        data-feature-name="Footer Navigation" data-display-name="Apple Store Account"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Apple Store Account-footer-link"> Apple Store Account
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.icloud.com" data-slot-name="section2"
+                                        data-feature-name="Footer Navigation" data-display-name="iCloud.com"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="iCloud.com-footer-link"> iCloud.com
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="as-globalfooter-directory-column">
+                        <input class="as-globalfooter-directory-column-section-state" type="checkbox"
+                            id="as-globalfooter-state-section-three" />
+                        <div class="as-globalfooter-directory-column-section">
+                            <label class="as-globalfooter-directory-column-section-label"
+                                for="as-globalfooter-state-section-three" data-asext-evar="eVar6"
+                                data-asext-feature="footer" data-asext-part="Apple Store" data-asext-action="expand"
+                                data-asext-action-toggle="collapse">
+                                <h3 class="as-globalfooter-directory-column-section-title">Apple Store</h3>
+                            </label>
+                            <a href="#as-globalfooter-state-section-three"
+                                class="as-globalfooter-directory-column-section-anchor as-globalfooter-directory-column-section-anchor-open"><span
+                                    class="as-globalfooter-directory-column-section-anchor-label">Open
+                                    Menusection-three</span></a>
+                            <a href="#"
+                                class="as-globalfooter-direcotry-column-section-anchor as-globalfooter-directory-column-section-anchor-close"><span
+                                    class="as-globalfooter-directory-column-section-anchor-label">Close
+                                    Menusection-three</span></a>
+                            <ul class="as-globalfooter-directory-column-section-list">
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/retail/" data-slot-name="section3"
+                                        data-feature-name="Footer Navigation" data-display-name="Find a Store"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Find a Store-footer-link"> Find a Store
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/retail/geniusbar/" data-slot-name="section3"
+                                        data-feature-name="Footer Navigation" data-display-name="Genius Bar"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Genius Bar-footer-link"> Genius Bar
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/retail/learn/" data-slot-name="section3"
+                                        data-feature-name="Footer Navigation" data-display-name="Today at Apple"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Today at Apple-footer-link"> Today at Apple
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/today/camp/" data-slot-name="section3"
+                                        data-feature-name="Footer Navigation" data-display-name="Apple Camp"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Apple Camp-footer-link"> Apple Camp
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://itunes.apple.com/us/app/apple-store/id375380948?mt=8"
+                                        data-slot-name="section3" data-feature-name="Footer Navigation"
+                                        data-display-name="Apple Store App"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Apple Store App-footer-link"> Apple Store App
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="/shop/refurbished" data-slot-name="section3"
+                                        data-feature-name="Footer Navigation"
+                                        data-display-name="Refurbished and Clearance"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Refurbished and Clearance-footer-link"> Refurbished and Clearance
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="/shop/browse/finance/PaypalFinancingLandingPage" data-slot-name="section3"
+                                        data-feature-name="Footer Navigation" data-display-name="Financing"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Financing-footer-link"> Financing
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="/shop/trade-in" data-slot-name="section3"
+                                        data-feature-name="Footer Navigation" data-display-name="Apple Trade In"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Apple Trade In-footer-link"> Apple Trade In
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://secure.store.apple.com/shop/order/list" data-slot-name="section3"
+                                        data-feature-name="Footer Navigation" data-display-name="Order Status"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Order Status-footer-link"> Order Status
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="/shop/help" data-slot-name="section3" data-feature-name="Footer Navigation"
+                                        data-display-name="Shopping Help"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Shopping Help-footer-link"> Shopping Help
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="as-globalfooter-directory-column">
+                        <input class="as-globalfooter-directory-column-section-state" type="checkbox"
+                            id="as-globalfooter-state-section-four-0" />
+                        <div class="as-globalfooter-directory-column-section">
+                            <label class="as-globalfooter-directory-column-section-label"
+                                for="as-globalfooter-state-section-four-0" data-asext-evar="eVar6"
+                                data-asext-feature="footer" data-asext-part="For Business" data-asext-action="expand"
+                                data-asext-action-toggle="collapse">
+                                <h3 class="as-globalfooter-directory-column-section-title">For Business</h3>
+                            </label>
+                            <a href="#as-globalfooter-state-section-four-0"
+                                class="as-globalfooter-directory-column-section-anchor as-globalfooter-directory-column-section-anchor-open"><span
+                                    class="as-globalfooter-directory-column-section-anchor-label">Open
+                                    Menusection-four-0</span></a>
+                            <a href="#"
+                                class="as-globalfooter-direcotry-column-section-anchor as-globalfooter-directory-column-section-anchor-close"><span
+                                    class="as-globalfooter-directory-column-section-anchor-label">Close
+                                    Menusection-four-0</span></a>
+                            <ul class="as-globalfooter-directory-column-section-list">
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/business/" data-slot-name="section4"
+                                        data-feature-name="Footer Navigation" data-display-name="Apple and Business"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Apple and Business-footer-link"> Apple and Business
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/retail/business/" data-slot-name="section4"
+                                        data-feature-name="Footer Navigation" data-display-name="Shop for Business"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Shop for Business-footer-link"> Shop for Business
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                        <input class="as-globalfooter-directory-column-section-state" type="checkbox"
+                            id="as-globalfooter-state-section-four-1" />
+                        <div class="as-globalfooter-directory-column-section">
+                            <label class="as-globalfooter-directory-column-section-label"
+                                for="as-globalfooter-state-section-four-1" data-asext-evar="eVar6"
+                                data-asext-feature="footer" data-asext-part="For Education" data-asext-action="expand"
+                                data-asext-action-toggle="collapse">
+                                <h3 class="as-globalfooter-directory-column-section-title">For Education</h3>
+                            </label>
+                            <a href="#as-globalfooter-state-section-four-1"
+                                class="as-globalfooter-directory-column-section-anchor as-globalfooter-directory-column-section-anchor-open"><span
+                                    class="as-globalfooter-directory-column-section-anchor-label">Open
+                                    Menusection-four-1</span></a>
+                            <a href="#"
+                                class="as-globalfooter-direcotry-column-section-anchor as-globalfooter-directory-column-section-anchor-close"><span
+                                    class="as-globalfooter-directory-column-section-anchor-label">Close
+                                    Menusection-four-1</span></a>
+                            <ul class="as-globalfooter-directory-column-section-list">
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/education/" data-slot-name="section4"
+                                        data-feature-name="Footer Navigation" data-display-name="Apple and Education"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Apple and Education-footer-link"> Apple and Education
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/education/k12/how-to-buy/" data-slot-name="section4"
+                                        data-feature-name="Footer Navigation" data-display-name="Shop for K-12"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Shop for K-12-footer-link"> Shop for K-12
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="/shop/education-pricing" data-slot-name="section4"
+                                        data-feature-name="Footer Navigation" data-display-name="Shop for College"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Shop for College-footer-link"> Shop for College
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                        <input class="as-globalfooter-directory-column-section-state" type="checkbox"
+                            id="as-globalfooter-state-section-four-2" />
+                        <div class="as-globalfooter-directory-column-section">
+                            <label class="as-globalfooter-directory-column-section-label"
+                                for="as-globalfooter-state-section-four-2" data-asext-evar="eVar6"
+                                data-asext-feature="footer" data-asext-part="For Healthcare" data-asext-action="expand"
+                                data-asext-action-toggle="collapse">
+                                <h3 class="as-globalfooter-directory-column-section-title">For Healthcare</h3>
+                            </label>
+                            <a href="#as-globalfooter-state-section-four-2"
+                                class="as-globalfooter-directory-column-section-anchor as-globalfooter-directory-column-section-anchor-open"><span
+                                    class="as-globalfooter-directory-column-section-anchor-label">Open
+                                    Menusection-four-2</span></a>
+                            <a href="#"
+                                class="as-globalfooter-direcotry-column-section-anchor as-globalfooter-directory-column-section-anchor-close"><span
+                                    class="as-globalfooter-directory-column-section-anchor-label">Close
+                                    Menusection-four-2</span></a>
+                            <ul class="as-globalfooter-directory-column-section-list">
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/healthcare/" data-slot-name="section4"
+                                        data-feature-name="Footer Navigation" data-display-name="Apple in Healthcare"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Apple in Healthcare-footer-link"> Apple in Healthcare
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/healthcare/apple-watch/" data-slot-name="section4"
+                                        data-feature-name="Footer Navigation" data-display-name="Health on Apple Watch"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Health on Apple Watch-footer-link"> Health on Apple Watch
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/healthcare/health-records/" data-slot-name="section4"
+                                        data-feature-name="Footer Navigation"
+                                        data-display-name="Health Records on iPhone"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Health Records on iPhone-footer-link"> Health Records on iPhone
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                        <input class="as-globalfooter-directory-column-section-state" type="checkbox"
+                            id="as-globalfooter-state-section-four-3" />
+                        <div class="as-globalfooter-directory-column-section">
+                            <label class="as-globalfooter-directory-column-section-label"
+                                for="as-globalfooter-state-section-four-3" data-asext-evar="eVar6"
+                                data-asext-feature="footer" data-asext-part="For Government" data-asext-action="expand"
+                                data-asext-action-toggle="collapse">
+                                <h3 class="as-globalfooter-directory-column-section-title">For Government</h3>
+                            </label>
+                            <a href="#as-globalfooter-state-section-four-3"
+                                class="as-globalfooter-directory-column-section-anchor as-globalfooter-directory-column-section-anchor-open"><span
+                                    class="as-globalfooter-directory-column-section-anchor-label">Open
+                                    Menusection-four-3</span></a>
+                            <a href="#"
+                                class="as-globalfooter-direcotry-column-section-anchor as-globalfooter-directory-column-section-anchor-close"><span
+                                    class="as-globalfooter-directory-column-section-anchor-label">Close
+                                    Menusection-four-3</span></a>
+                            <ul class="as-globalfooter-directory-column-section-list">
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/r/store/government" data-slot-name="section4"
+                                        data-feature-name="Footer Navigation" data-display-name="Shop for Government"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Shop for Government-footer-link"> Shop for Government
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="/shop/browse/home/veterans_military" data-slot-name="section4"
+                                        data-feature-name="Footer Navigation"
+                                        data-display-name="Shop for Veterans and Military"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Shop for Veterans and Military-footer-link"> Shop for Veterans and
+                                        Military
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="as-globalfooter-directory-column">
+                        <input class="as-globalfooter-directory-column-section-state" type="checkbox"
+                            id="as-globalfooter-state-section-five-0" />
+                        <div class="as-globalfooter-directory-column-section">
+                            <label class="as-globalfooter-directory-column-section-label"
+                                for="as-globalfooter-state-section-five-0" data-asext-evar="eVar6"
+                                data-asext-feature="footer" data-asext-part="Apple Values" data-asext-action="expand"
+                                data-asext-action-toggle="collapse">
+                                <h3 class="as-globalfooter-directory-column-section-title">Apple Values</h3>
+                            </label>
+                            <a href="#as-globalfooter-state-section-five-0"
+                                class="as-globalfooter-directory-column-section-anchor as-globalfooter-directory-column-section-anchor-open"><span
+                                    class="as-globalfooter-directory-column-section-anchor-label">Open
+                                    Menusection-five-0</span></a>
+                            <a href="#"
+                                class="as-globalfooter-direcotry-column-section-anchor as-globalfooter-directory-column-section-anchor-close"><span
+                                    class="as-globalfooter-directory-column-section-anchor-label">Close
+                                    Menusection-five-0</span></a>
+                            <ul class="as-globalfooter-directory-column-section-list">
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/accessibility/" data-slot-name="section5"
+                                        data-feature-name="Footer Navigation" data-display-name="Accessibility"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Accessibility-footer-link"> Accessibility
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/education/connectED/" data-slot-name="section5"
+                                        data-feature-name="Footer Navigation" data-display-name="Education"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Education-footer-link"> Education
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/environment/" data-slot-name="section5"
+                                        data-feature-name="Footer Navigation" data-display-name="Environment"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Environment-footer-link"> Environment
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/diversity/" data-slot-name="section5"
+                                        data-feature-name="Footer Navigation"
+                                        data-display-name="Inclusion and Diversity"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Inclusion and Diversity-footer-link"> Inclusion and Diversity
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/privacy/" data-slot-name="section5"
+                                        data-feature-name="Footer Navigation" data-display-name="Privacy"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Privacy-footer-link"> Privacy
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/racial-equity-justice-initiative/"
+                                        data-slot-name="section5" data-feature-name="Footer Navigation"
+                                        data-display-name="Racial Equity and Justice"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Racial Equity and Justice-footer-link"> Racial Equity and Justice
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/supplier-responsibility/" data-slot-name="section5"
+                                        data-feature-name="Footer Navigation"
+                                        data-display-name="Supplier Responsibility"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Supplier Responsibility-footer-link"> Supplier Responsibility
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                        <input class="as-globalfooter-directory-column-section-state" type="checkbox"
+                            id="as-globalfooter-state-section-five-1" />
+                        <div class="as-globalfooter-directory-column-section">
+                            <label class="as-globalfooter-directory-column-section-label"
+                                for="as-globalfooter-state-section-five-1" data-asext-evar="eVar6"
+                                data-asext-feature="footer" data-asext-part="About Apple" data-asext-action="expand"
+                                data-asext-action-toggle="collapse">
+                                <h3 class="as-globalfooter-directory-column-section-title">About Apple</h3>
+                            </label>
+                            <a href="#as-globalfooter-state-section-five-1"
+                                class="as-globalfooter-directory-column-section-anchor as-globalfooter-directory-column-section-anchor-open"><span
+                                    class="as-globalfooter-directory-column-section-anchor-label">Open
+                                    Menusection-five-1</span></a>
+                            <a href="#"
+                                class="as-globalfooter-direcotry-column-section-anchor as-globalfooter-directory-column-section-anchor-close"><span
+                                    class="as-globalfooter-directory-column-section-anchor-label">Close
+                                    Menusection-five-1</span></a>
+                            <ul class="as-globalfooter-directory-column-section-list">
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/newsroom/" data-slot-name="section5"
+                                        data-feature-name="Footer Navigation" data-display-name="Newsroom"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Newsroom-footer-link"> Newsroom
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/leadership/" data-slot-name="section5"
+                                        data-feature-name="Footer Navigation" data-display-name="Apple Leadership"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Apple Leadership-footer-link"> Apple Leadership
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/jobs/us/" data-slot-name="section5"
+                                        data-feature-name="Footer Navigation" data-display-name="Career Opportunities"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Career Opportunities-footer-link"> Career Opportunities
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://investor.apple.com" data-slot-name="section5"
+                                        data-feature-name="Footer Navigation" data-display-name="Investors"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Investors-footer-link"> Investors
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/compliance" data-slot-name="section5"
+                                        data-feature-name="Footer Navigation"
+                                        data-display-name="Ethics &amp; Compliance"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Ethics & Compliance-footer-link"> Ethics & Compliance
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/apple-events/" data-slot-name="section5"
+                                        data-feature-name="Footer Navigation" data-display-name="Events"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Events-footer-link"> Events
+                                    </a>
+                                </li>
+                                <li class="as-globalfooter-directory-column-section-item">
+                                    <a href="https://www.apple.com/contact/" data-slot-name="section5"
+                                        data-feature-name="Footer Navigation" data-display-name="Contact Apple"
+                                        class="as-globalfooter-directory-column-section-link"
+                                        data-autom="Contact Apple-footer-link"> Contact Apple
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </nav>
+
+                <section class="as-globalfooter-mini" data-nosnippet>
+                    <div class="as-globalfooter-mini-shop">
+                        <p>More ways to shop: <span class="nowrap"><a href="https://www.apple.com/retail"
+                                    data-slot-name="footerConfig" data-feature-name="Footer Navigation"
+                                    data-display-name="Find an Apple Store">Find an Apple Store</a></span> or <a
+                                href="https://locate.apple.com" data-slot-name="footerConfig"
+                                data-feature-name="Footer Navigation" data-display-name="other retailer">other
+                                retailer</a> near you. Or <span class="nowrap">call <span>1‑800‑MY‑APPLE</span></span>.
+                        </p>
+                    </div>
+                    <div class="as-globalfooter-mini-locale">
+                        <a href="https://www.apple.com/choose-your-country" data-slot-name="footerConfig"
+                            data-feature-name="Footer Navigation" data-display-name="Country Selector"
+                            class="as-globalfooter-mini-locale-link" data-autom="footer"> United States
+                        </a>
+                    </div>
+                    <div class="as-globalfooter-mini-legal">
+                        <div class="as-globalfooter-mini-legal-copyright">
+                            Copyright &copy; 2022 Apple Inc. All rights reserved.
+                        </div>
+                        <div class="as-globalfooter-mini-legal-links">
+                            <a href="https://www.apple.com/privacy/privacy-policy" data-slot-name="footerConfig"
+                                data-feature-name="Footer Navigation" data-display-name="Privacy Policy"
+                                class="as-globalfooter-mini-legal-link" data-autom="footer">Privacy Policy</a><a
+                                href="https://apple.com/legal/internet-services/terms/site.html"
+                                data-slot-name="footerConfig" data-feature-name="Footer Navigation"
+                                data-display-name="Terms of Use" class="as-globalfooter-mini-legal-link"
+                                data-autom="footer">Terms of Use</a><a href="/shop/open/salespolicies"
+                                data-slot-name="footerConfig" data-feature-name="Footer Navigation"
+                                data-display-name="Sales and Refunds" class="as-globalfooter-mini-legal-link"
+                                target="new" data-autom="footer">Sales and Refunds</a><a href="https://apple.com/legal"
+                                data-slot-name="footerConfig" data-feature-name="Footer Navigation"
+                                data-display-name="Legal" class="as-globalfooter-mini-legal-link"
+                                data-autom="footer">Legal</a><a href="/shop/browse/sitemap"
+                                data-slot-name="footerConfig" data-feature-name="Footer Navigation"
+                                data-display-name="Sitemap" class="as-globalfooter-mini-legal-link"
+                                data-autom="footer">Site Map</a>
+                        </div>
+                    </div>
+                </section>
+
+            </div>
+        </footer>
+
+        <script>
+
+
+            window.GLOBAL_ASSETS = {
+                open: "Open",
+                close: "Close",
+                top: "Top",
+                right: "Right",
+                bottom: "Bottom",
+                left: "Left",
+                next: "Next",
+                previous: "Previous",
+                selected: "Selected",
+                show: "Show",
+                hide: "Hide",
+                play: "Play",
+                pause: "Pause",
+                mute: "",
+                unmute: "Unmute",
+                loading: "Loading",
+                fullscreen: "Show fullscreen",
+                pip: "Show picture-in-picture",
+                airplay: "Show AirPlay",
+                captions: "Show captions",
+                showMore: "Show more",
+                showLess: "Show less",
+                more: "More",
+                less: "Less",
+                item: "Item",
+                image: "Image",
+                video: "Video",
+                edit: "Edit",
+                change: "Change",
+                update: "Update",
+                add: "Add",
+                remove: "Remove",
+                save: "Save",
+                cancel: "Cancel",
+                submit: "Submit",
+                reset: "Reset",
+                opensNewWindow: "(Opens in a new window)",
+                search: "Search"
+            };
+
+
+        </script>
+    </div>
+
+
+
+
+
+
+
+
+    <script>dciddstr = '8e8df2bce89047dc8442b415c2c098357986db4f799da39b30a523ae7e0b32afd7c91ea550a4f0ce2b389fc2993c5e6bf07d1718ee4016738f7cecc601270a7087c971a38c07f74766ec7d15e6037c80a55a7c6afcfe14a0abe5e7970c9bffe8b54b0fc3040437517a628a49060e82557e6170b40b6ffcdcd402adde47a3af2b9c7d9b883af38683f82dc1cacd83bc431d1ab321798ab3c465e360f7123f1b898690c6f262fbf458d913963ee30ec381856c3ea3a31ec81127aefe0320c35a70b6b28f7185bb2d928cedb618ca8f09bbd673ccfc239be54b80c7e2d9349db17f3c8908427838612dbc094528e6fa892eb0d7b58009f4284f35d063e285ead2e462bb7ce4da4e0035f97421a47e4e1a5094c3587032fc163fdb5ef535e2907cb3b0f1ad5504a87ebdea50c61adf3204a69e2c1789462493e9346d14e1546053512b96c66e4a74626e9f02ad34e0c41ad7c24cd245745018cff2ab202672a2501dd7f8e3a91ca651f1bcc865838e89a4624d0bef4033340e43c0f71feee2329d3ec89d1c083fba270f2c3efb676b60fde37050f8f61e99ec9a3ff76684681d61bdf98fc150d780c97f75f6a4f4966ae09478e2552bb57370ee66d42e1676a4b883cc2030aca6c88103d94f9e7bc81f03726955ef62f11841af7606fca931a339bd8995a630e60306f8d1c2bad90e37152153a5411eef0390f8aeea8d32ee2998ee7e44bd3ac61306179eefc625cd6eecd0325cca3f71f89dcde5e5596145fa337886fb5c5c42f259c055d8a3eeeaf2414bff3a393c56dae1d42428e1ac9f997d16c814b558d36a6060a2ea0a3142fecf1719311e122c36c265d194e99e1c99e0c1a10004b85dabd50e77948bcff661913faf6d19839e8d5a62634f589b606f0b393b264688a349dca44f17f4cc5f48caeb15ca7bda9db128751060cb';</script>
+
+
+
+
+
+
+    <div id="portal"></div>
+</body>
+
+</html>


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

The US store was updated recently, and now it uses a different CSS class for the product list; other stores are still using the previous one.

With this change in the US store, the library can't find products in this store.

### Change description
<!-- What does your code do? -->

Use a list of CSS classes instead of a single one to search for the product list.


<!-- ### Additional Notes
Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

* [x] PR address a single concern.
* [ ] PR title and description are appropriately filled.
* [x] Changes will be merged in `main.`
* [x] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] Docs are updated (at least the `README.md`, if needed).
* [x] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well-formatted.