### PR TITLE
Add --max-price and --max-previous-price options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,4 +30,4 @@ fix-isort:
 test:
 	pytest tests
 
-ready: lint test
+ready: lint test ## Make sure we're ready to ship the code in a PR

--- a/cli/rfrb
+++ b/cli/rfrb
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import decimal
+
 import click
 
 from refurbished import ProductNotFoundError, Store
@@ -16,12 +18,23 @@ from refurbished import ProductNotFoundError, Store
 @click.option(
     "--min-saving-percentage", default=0.0, help="Minimum saving percentage"
 )
+@click.option(
+    "--max-price", default=None, type=decimal.Decimal, help="Maximum price"
+)
+@click.option(
+    "--max-previous-price",
+    default=None,
+    type=decimal.Decimal,
+    help="Maximum previous price",
+)
 @click.option("--name", default=None, help="Filter product by name")
 def get_products(
     country: str,
     product_family: str,
     min_saving: float,
     min_saving_percentage: float,
+    max_price: decimal.Decimal,
+    max_previous_price: decimal.Decimal,
     name: str,
 ):
     # creates a store for the selected country
@@ -39,6 +52,8 @@ def get_products(
         for p in search_products(
             min_saving=min_saving,
             min_saving_percentage=min_saving_percentage,
+            max_price=max_price,
+            max_previous_price=max_previous_price,
             name=name,
         ):
             click.echo(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,3 +26,39 @@ class TestCLI:
             "Product 'macs' is not available in the 'be' store"
             in result.output
         )
+
+    @patch(
+        "requests.Session.get",
+        side_effect=ResponseBuilder("it_ipad.html"),
+    )
+    def test_max_price(self, _):
+        runner = CliRunner()
+
+        result = runner.invoke(
+            rfrb.get_products, ["it", "ipads", "--max-price", "400"]
+        )
+
+        assert result.exit_code == 0
+        assert (
+            # this is the only product that matches the max price
+            "449.00 389.00 60.00 (13.3630289532294%) iPad Wi-Fi 128GB ricondizionato - Argento (sesta generazione)" # noqa
+            in result.output
+        )
+
+    @patch(
+        "requests.Session.get",
+        side_effect=ResponseBuilder("it_ipad.html"),
+    )
+    def test_max_previous_price(self, _):
+        runner = CliRunner()
+
+        result = runner.invoke(
+            rfrb.get_products, ["it", "ipads", "--max-previous-price", "500"]
+        )
+
+        assert result.exit_code == 0
+        assert (
+            # this is the only product that matches the max previous price
+            "449.00 389.00 60.00 (13.3630289532294%) iPad Wi-Fi 128GB ricondizionato - Argento (sesta generazione)" # noqa
+            in result.output
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,7 +41,7 @@ class TestCLI:
         assert result.exit_code == 0
         assert (
             # this is the only product that matches the max price
-            "449.00 389.00 60.00 (13.3630289532294%) iPad Wi-Fi 128GB ricondizionato - Argento (sesta generazione)" # noqa
+            "449.00 389.00 60.00 (13.3630289532294%) iPad Wi-Fi 128GB ricondizionato - Argento (sesta generazione)"  # noqa
             in result.output
         )
 
@@ -59,6 +59,6 @@ class TestCLI:
         assert result.exit_code == 0
         assert (
             # this is the only product that matches the max previous price
-            "449.00 389.00 60.00 (13.3630289532294%) iPad Wi-Fi 128GB ricondizionato - Argento (sesta generazione)" # noqa
+            "449.00 389.00 60.00 (13.3630289532294%) iPad Wi-Fi 128GB ricondizionato - Argento (sesta generazione)"  # noqa
             in result.output
         )


### PR DESCRIPTION
Sometimes you want to search for product with a max price (or previous price) ceiling. Budget anyone?

Here's an example:

```shell
$ rfrb it ipads --max-price 500
559.00 479.00 80.00 (14.311270125223613%) iPad Air Wi-Fi 64GB ricondizionato - Oro (terza generazione)
```

Grep is fine, but something built in is minimum we should offer.