### PR TITLE
Add text, json, and ndjson output formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,57 @@ $ rfrb it macs --min-saving=300
 2459.00 2109.00 350.00 (14.233428222854819%) MacBook Pro 13,3" ricondizionato con Intel Core i5 quad-core a 2,0GHz e display Retina - Argento
 ```
 
+#### Output formats
+
+Refurbished supports several output formats.
+
+##### text
+
+```shell
+$ rfrb it ipads --max-price 539
+559.00 479.00 80.00 (14.311270125223613%) iPad Air Wi-Fi 64GB ricondizionato - Oro (terza generazione)
+639.00 539.00 100.00 (15.64945226917058%) iPad Air Wi-Fi 64GB ricondizionato - Celeste (quarta generazione)
+```
+
+##### json
+
+```shell
+$ python cli/rfrb it ipads --max-price 539 --format json
+[
+  {
+    "name": "iPad Air Wi-Fi 64GB ricondizionato - Oro (terza generazione)",
+    "family": "ipad",
+    "url": "https://www.apple.com/it/shop/product/FUUL2TY/A/iPad-Air-Wi-Fi-64GB-ricondizionato-Oro-terza-generazione",
+    "price": 479.0,
+    "previous_price": 559.0,
+    "savings_price": 80.0,
+    "saving_percentage": 0.14311270125223613,
+    "model": "FUUL2TY"
+  },
+  {
+    "name": "iPad Air Wi-Fi 64GB ricondizionato - Celeste (quarta generazione)",
+    "family": "ipad",
+    "url": "https://www.apple.com/it/shop/product/FYFQ2TY/A/iPad-Air-Wi-Fi-64GB-ricondizionato-Celeste-quarta-generazione",
+    "price": 539.0,
+    "previous_price": 639.0,
+    "savings_price": 100.0,
+    "saving_percentage": 0.1564945226917058,
+    "model": "FYFQ2TY"
+  }
+]
+```
+
+##### ndjson
+
+```shell
+$ rfrb it ipads --max-price 539 --format ndjson
+{"name": "iPad Air Wi-Fi 64GB ricondizionato - Oro (terza generazione)", "family": "ipad", "url": "https://www.apple.com/it/shop/product/FUUL2TY/A/iPad-Air-Wi-Fi-64GB-ricondizionato-Oro-terza-generazione", "price": 479.0, "previous_price": 559.0, "savings_price": 80.0, "saving_percentage": 0.14311270125223613, "model": "FUUL2TY"}
+{"name": "iPad Air Wi-Fi 64GB ricondizionato - Celeste (quarta generazione)", "family": "ipad", "url": "https://www.apple.com/it/shop/product/FYFQ2TY/A/iPad-Air-Wi-Fi-64GB-ricondizionato-Celeste-quarta-generazione", "price": 539.0, "previous_price": 639.0, "savings_price": 100.0, "saving_percentage": 0.1564945226917058, "model": "FYFQ2TY"}
+{"name": "iPad Air Wi-Fi 64GB ricondizionato - Verde (quarta generazione)", "family": "ipad", "url": "https://www.apple.com/it/shop/product/FYFR2TY/A/iPad-Air-Wi-Fi-64GB-ricondizionato-Verde-quarta-generazione", "price": 539.0, "previous_price": 639.0, "savings_price": 100.0, "saving_percentage": 0.1564945226917058, "model": "FYFR2TY"}
+
+```
+
+
 ### Library
 
 The same search using the `refurbished` package in your own project:
@@ -116,6 +167,7 @@ tests/test_refurbished.py ......                                                
 
 * [beautifulsoup4](https://www.crummy.com/software/BeautifulSoup/)
 * [price-parser](https://github.com/scrapinghub/price-parser)
+* [pydantic](https://pydantic-docs.helpmanual.io/)
 * [requests](https://requests.readthedocs.io/en/master/)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ rfrb it ipads --max-price 539
 ##### json
 
 ```shell
-$ python cli/rfrb it ipads --max-price 539 --format json
+$ rfrb it ipads --max-price 539 --format json
 [
   {
     "name": "iPad Air Wi-Fi 64GB ricondizionato - Oro (terza generazione)",
@@ -65,8 +65,6 @@ $ python cli/rfrb it ipads --max-price 539 --format json
 $ rfrb it ipads --max-price 539 --format ndjson
 {"name": "iPad Air Wi-Fi 64GB ricondizionato - Oro (terza generazione)", "family": "ipad", "url": "https://www.apple.com/it/shop/product/FUUL2TY/A/iPad-Air-Wi-Fi-64GB-ricondizionato-Oro-terza-generazione", "price": 479.0, "previous_price": 559.0, "savings_price": 80.0, "saving_percentage": 0.14311270125223613, "model": "FUUL2TY"}
 {"name": "iPad Air Wi-Fi 64GB ricondizionato - Celeste (quarta generazione)", "family": "ipad", "url": "https://www.apple.com/it/shop/product/FYFQ2TY/A/iPad-Air-Wi-Fi-64GB-ricondizionato-Celeste-quarta-generazione", "price": 539.0, "previous_price": 639.0, "savings_price": 100.0, "saving_percentage": 0.1564945226917058, "model": "FYFQ2TY"}
-{"name": "iPad Air Wi-Fi 64GB ricondizionato - Verde (quarta generazione)", "family": "ipad", "url": "https://www.apple.com/it/shop/product/FYFR2TY/A/iPad-Air-Wi-Fi-64GB-ricondizionato-Verde-quarta-generazione", "price": 539.0, "previous_price": 639.0, "savings_price": 100.0, "saving_percentage": 0.1564945226917058, "model": "FYFR2TY"}
-
 ```
 
 

--- a/cli/rfrb
+++ b/cli/rfrb
@@ -3,7 +3,7 @@ import decimal
 
 import click
 
-from refurbished import ProductNotFoundError, Store
+from refurbished import ProductNotFoundError, Store, feedback
 
 
 @click.command()
@@ -28,6 +28,7 @@ from refurbished import ProductNotFoundError, Store
     help="Maximum previous price",
 )
 @click.option("--name", default=None, help="Filter product by name")
+@click.option("--format", default="text", help="Set output format")
 def get_products(
     country: str,
     product_family: str,
@@ -36,37 +37,40 @@ def get_products(
     max_price: decimal.Decimal,
     max_previous_price: decimal.Decimal,
     name: str,
+    format: str,
 ):
+    # set feedback
+    feedback.set_format(format)
+
     # creates a store for the selected country
     store = Store(country)
 
     # checking the selected procuct is supported by refurbished
     search_products = getattr(store, f"get_{product_family}", None)
     if not callable(search_products):
-        click.echo(
-            f"Product family {product_family} is supported by refurbished"
+        feedback.echo(
+            f"Product family {product_family} is not supported by refurbished",
+            err=True,
         )
         return
 
     try:
-        for p in search_products(
+        products = search_products(
             min_saving=min_saving,
             min_saving_percentage=min_saving_percentage,
             max_price=max_price,
             max_previous_price=max_previous_price,
             name=name,
-        ):
-            click.echo(
-                f"{p.previous_price} "
-                f"{p.price} "
-                f"{p.savings_price} "
-                f"({p.saving_percentage * 100}%) {p.name}"
-            )
+        )
+
+        feedback.result(feedback.ProductsResult(products))
+
     except ProductNotFoundError:
         # the selected procuct is not available on this store
-        click.echo(
+        feedback.echo(
             f"Product '{product_family}' is "
-            f"not available in the '{country}' store"
+            f"not available in the '{country}' store",
+            err=True,
         )
 
 

--- a/refurbished/feedback.py
+++ b/refurbished/feedback.py
@@ -1,0 +1,65 @@
+import json
+from typing import List
+
+import click
+from pydantic.json import pydantic_encoder
+
+from .model import Product
+
+
+class Feedback:
+    def __init__(self, format):
+        self.format = format
+
+    def echo(self, text, nl=True, err=False):
+        click.echo(text, nl=nl, err=err)
+
+    def result(self, result):
+        if self.format == "text":
+            click.echo(result.str(), nl=False)
+        elif self.format == "json":
+            click.echo(
+                json.dumps(result.data(), indent=2, default=pydantic_encoder),
+                nl=False,
+            )
+        elif self.format == "ndjson":
+            for product in result.data():
+                click.echo(
+                    json.dumps(product, default=pydantic_encoder), nl=False
+                )
+
+
+_current_feedback = Feedback("text")
+
+
+def set_format(format):
+    _current_feedback.format = format
+
+
+def echo(value, nl=True, err=False):
+    _current_feedback.echo(value, nl=nl, err=err)
+
+
+def result(values):
+    _current_feedback.result(values)
+
+
+class ProductsResult:
+    def __init__(self, values: List[Product]):
+        self.values = values
+
+    def str(self) -> str:
+        if len(self.values) == 0:
+            return "No products found"
+        out = ""
+        for p in self.values:
+            out += (
+                f"{p.previous_price} "
+                f"{p.price} "
+                f"{p.savings_price} "
+                f"({p.saving_percentage * 100}%) {p.name}\n"
+            )
+        return out
+
+    def data(self):
+        return self.values

--- a/refurbished/feedback.py
+++ b/refurbished/feedback.py
@@ -16,16 +16,23 @@ class Feedback:
 
     def result(self, result):
         if self.format == "text":
-            click.echo(result.str(), nl=False)
+            click.echo(
+                result.str(),
+                # delefate newlines to the result class
+                nl=False)
         elif self.format == "json":
             click.echo(
                 json.dumps(result.data(), indent=2, default=pydantic_encoder),
+                # delegate newline to json.dumps
                 nl=False,
             )
         elif self.format == "ndjson":
             for product in result.data():
                 click.echo(
-                    json.dumps(product, default=pydantic_encoder), nl=False
+                    json.dumps(product, default=pydantic_encoder),
+                    # The newline is required by the format to separate the
+                    # JSON objects
+                    nl=True,
                 )
 
 

--- a/refurbished/feedback.py
+++ b/refurbished/feedback.py
@@ -19,7 +19,8 @@ class Feedback:
             click.echo(
                 result.str(),
                 # delefate newlines to the result class
-                nl=False)
+                nl=False,
+            )
         elif self.format == "json":
             click.echo(
                 json.dumps(result.data(), indent=2, default=pydantic_encoder),

--- a/refurbished/model.py
+++ b/refurbished/model.py
@@ -1,6 +1,8 @@
 import decimal
 import re
-from dataclasses import dataclass
+
+# from dataclasses import dataclass
+from pydantic.dataclasses import dataclass
 
 
 @dataclass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-beautifulsoup4==4.11.1
-click==8.1.3
-requests==2.28.1
-price-parser==0.3.4
+beautifulsoup4>=4.11.1
+click>=8.1.3
+requests>=2.28.1
+price-parser>=0.3.4
+pydantic>=1.10.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture(scope="session")
+def cli_runner():
+    return CliRunner()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,12 +16,12 @@ class TestCLI:
         "requests.Session.get",
         side_effect=ResponseBuilder("page_not_found.html", status_code=404),
     )
-    def test_product_ipad_it(self, _):
+    def test_product_ipad_it(self, _, cli_runner: CliRunner):
         runner = CliRunner()
 
         result = runner.invoke(rfrb.get_products, ["be", "macs"])
 
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output
         assert (
             "Product 'macs' is not available in the 'be' store"
             in result.output
@@ -31,7 +31,7 @@ class TestCLI:
         "requests.Session.get",
         side_effect=ResponseBuilder("it_ipad.html"),
     )
-    def test_max_price(self, _):
+    def test_max_price(self, _, cli_runner: CliRunner):
         runner = CliRunner()
 
         result = runner.invoke(
@@ -49,7 +49,7 @@ class TestCLI:
         "requests.Session.get",
         side_effect=ResponseBuilder("it_ipad.html"),
     )
-    def test_max_previous_price(self, _):
+    def test_max_previous_price(self, _, cli_runner: CliRunner):
         runner = CliRunner()
 
         result = runner.invoke(

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -66,3 +66,19 @@ class TestFeedback(object):
   }
 ]"""  # noqa: E501
         )
+
+    @patch(
+        "requests.Session.get",
+        side_effect=ResponseBuilder("it_ipad.html"),
+    )
+    def test_ndjson_format(self, _, cli_runner: CliRunner):
+        result = cli_runner.invoke(
+            rfrb.get_products,
+            ["it", "ipads", "--max-price", "389", "--format", "ndjson"],
+        )
+
+        assert result.exit_code == 0
+        assert (
+            result.output
+            == '{"name": "iPad Wi-Fi 128GB ricondizionato - Argento (sesta generazione)", "family": "ipad", "url": "https://www.apple.com/it/shop/product/FR7K2TY/A/Refurbished-iPad-Wi-Fi-128GB-Silver-6th-Generation", "price": 389.0, "previous_price": 449.0, "savings_price": 60.0, "saving_percentage": 0.133630289532294, "model": "FR7K2TY"}\n'  # noqa: E501
+        )

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -1,0 +1,68 @@
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from . import ResponseBuilder, import_module
+
+rfrb = import_module("rfrb", "cli/rfrb")
+
+
+class TestFeedback(object):
+    @patch(
+        "requests.Session.get",
+        side_effect=ResponseBuilder("it_ipad.html"),
+    )
+    def test_default_format(self, _, cli_runner: CliRunner):
+        result = cli_runner.invoke(
+            rfrb.get_products, ["it", "ipads", "--max-price", "389"]
+        )
+
+        assert result.exit_code == 0
+        assert (
+            result.output
+            == "449.00 389.00 60.00 (13.3630289532294%) iPad Wi-Fi 128GB ricondizionato - Argento (sesta generazione)\n"  # noqa: E501
+        )
+
+    @patch(
+        "requests.Session.get",
+        side_effect=ResponseBuilder("it_ipad.html"),
+    )
+    def test_text_format(self, _, cli_runner: CliRunner):
+        result = cli_runner.invoke(
+            rfrb.get_products,
+            ["it", "ipads", "--max-price", "389", "--format", "text"],
+        )
+
+        assert result.exit_code == 0
+        assert (
+            result.output
+            == "449.00 389.00 60.00 (13.3630289532294%) iPad Wi-Fi 128GB ricondizionato - Argento (sesta generazione)\n"  # noqa: E501
+        )
+
+    @patch(
+        "requests.Session.get",
+        side_effect=ResponseBuilder("it_ipad.html"),
+    )
+    def test_json_format(self, _, cli_runner: CliRunner):
+        result = cli_runner.invoke(
+            rfrb.get_products,
+            ["it", "ipads", "--max-price", "389", "--format", "json"],
+        )
+
+        assert result.exit_code == 0
+        # Output is pretty printed with two spaces indentation
+        assert (
+            result.output
+            == """[
+  {
+    "name": "iPad Wi-Fi 128GB ricondizionato - Argento (sesta generazione)",
+    "family": "ipad",
+    "url": "https://www.apple.com/it/shop/product/FR7K2TY/A/Refurbished-iPad-Wi-Fi-128GB-Silver-6th-Generation",
+    "price": 389.0,
+    "previous_price": 449.0,
+    "savings_price": 60.0,
+    "saving_percentage": 0.133630289532294,
+    "model": "FR7K2TY"
+  }
+]"""  # noqa: E501
+        )


### PR DESCRIPTION
Add a new `--format` option with support for `text`, `json`, and `ndjson` output formats.

```shell
$ rfrb it ipads --max-price 539
559.00 479.00 80.00 (14.311270125223613%) iPad Air Wi-Fi 64GB ricondizionato - Oro (terza generazione)
639.00 539.00 100.00 (15.64945226917058%) iPad Air Wi-Fi 64GB ricondizionato - Celeste (quarta generazione)


$ rfrb it ipads --max-price 539 --format json
[
  {
    "name": "iPad Air Wi-Fi 64GB ricondizionato - Oro (terza generazione)",
    "family": "ipad",
    "url": "https://www.apple.com/it/shop/product/FUUL2TY/A/iPad-Air-Wi-Fi-64GB-ricondizionato-Oro-terza-generazione",
    "price": 479.0,
    "previous_price": 559.0,
    "savings_price": 80.0,
    "saving_percentage": 0.14311270125223613,
    "model": "FUUL2TY"
  },
  {
    "name": "iPad Air Wi-Fi 64GB ricondizionato - Celeste (quarta generazione)",
    "family": "ipad",
    "url": "https://www.apple.com/it/shop/product/FYFQ2TY/A/iPad-Air-Wi-Fi-64GB-ricondizionato-Celeste-quarta-generazione",
    "price": 539.0,
    "previous_price": 639.0,
    "savings_price": 100.0,
    "saving_percentage": 0.1564945226917058,
    "model": "FYFQ2TY"
  }
]


$ rfrb it ipads --max-price 539 --format ndjson
{"name": "iPad Air Wi-Fi 64GB ricondizionato - Oro (terza generazione)", "family": "ipad", "url": "https://www.apple.com/it/shop/product/FUUL2TY/A/iPad-Air-Wi-Fi-64GB-ricondizionato-Oro-terza-generazione", "price": 479.0, "previous_price": 559.0, "savings_price": 80.0, "saving_percentage": 0.14311270125223613, "model": "FUUL2TY"}
{"name": "iPad Air Wi-Fi 64GB ricondizionato - Celeste (quarta generazione)", "family": "ipad", "url": "https://www.apple.com/it/shop/product/FYFQ2TY/A/iPad-Air-Wi-Fi-64GB-ricondizionato-Celeste-quarta-generazione", "price": 539.0, "previous_price": 639.0, "savings_price": 100.0, "saving_percentage": 0.1564945226917058, "model": "FYFQ2TY"}
```
```
```

Closes: #85 