### PR TITLE
Add a new 'store' field to the product

### DIFF
--- a/refurbished/__init__.py
+++ b/refurbished/__init__.py
@@ -12,7 +12,7 @@ from . import parser
 from .model import Product
 
 REFURBISHED_BASE_URL = (
-    "http://www.apple.com/%(country)s/shop/refurbished/%(product)s"
+    "http://www.apple.com/%(store)s/shop/refurbished/%(product)s"
 )
 
 
@@ -23,11 +23,11 @@ class ProductNotFoundError(Exception):
 class Store:
     """
     Get data from the Apple Certified Refurbished stores
-    (the store is different for each country where Apple operates).
+    (the store is different for each store where Apple operates).
     """
 
-    def __init__(self, country):
-        self.country = country
+    def __init__(self, store):
+        self.store = store
         # TODO: Check the /shop/refurbished page to determine which
         #   product families are available.
 
@@ -86,7 +86,7 @@ class Store:
         Fetch product information from the Apple refurbished page.
         """
         products_url = REFURBISHED_BASE_URL % dict(
-            country=self.country, product=product_family
+            store=self.store, product=product_family
         )
 
         with requests.Session() as session:
@@ -101,7 +101,9 @@ class Store:
                 raise Exception("Ooops, cannot fetch the product page.")
 
             # Parse HTML response from Apple website
-            products = parser.parse_products(product_family, resp.text)
+            products = parser.parse_products(
+                product_family, self.store, resp.text
+            )
 
             # set up the criteria to filter the products
             criteria = (

--- a/refurbished/model.py
+++ b/refurbished/model.py
@@ -13,6 +13,7 @@ class Product:
 
     name: str
     family: str
+    store: str
     url: str
     price: decimal.Decimal
     previous_price: decimal.Decimal
@@ -33,5 +34,7 @@ class Product:
         """
         A readable version for prints.
         """
-        return f"{self.price} ({'-{:.0%}'.format(self.saving_percentage)}) "
-        "- [{self.model}] {self.name} {self.url}"
+        return (
+            f"{self.price} ({'-{:.0%}'.format(self.saving_percentage)}) "
+            "- [{self.model}] {self.name} {self.url}"
+        )

--- a/refurbished/parser.py
+++ b/refurbished/parser.py
@@ -12,7 +12,11 @@ from price_parser import Price
 from .model import Product
 
 
-def parse_products(product_family: str, page: str) -> List[Product]:
+def parse_products(
+    family: str,
+    store: str,
+    page: str,
+) -> List[Product]:
     """
     Parse the HTML page source to extract product data.
     """
@@ -48,7 +52,8 @@ def parse_products(product_family: str, page: str) -> List[Product]:
     return [
         Product(
             name=_parse_name(product),
-            family=product_family,
+            family=family,
+            store=store,
             url=_parse_url(product, store_domain),
             price=_parse_current_price(product),
             previous_price=_parse_previous_price(product),

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -57,6 +57,7 @@ class TestFeedback(object):
   {
     "name": "iPad Wi-Fi 128GB ricondizionato - Argento (sesta generazione)",
     "family": "ipad",
+    "store": "it",
     "url": "https://www.apple.com/it/shop/product/FR7K2TY/A/Refurbished-iPad-Wi-Fi-128GB-Silver-6th-Generation",
     "price": 389.0,
     "previous_price": 449.0,
@@ -80,5 +81,5 @@ class TestFeedback(object):
         assert result.exit_code == 0
         assert (
             result.output
-            == '{"name": "iPad Wi-Fi 128GB ricondizionato - Argento (sesta generazione)", "family": "ipad", "url": "https://www.apple.com/it/shop/product/FR7K2TY/A/Refurbished-iPad-Wi-Fi-128GB-Silver-6th-Generation", "price": 389.0, "previous_price": 449.0, "savings_price": 60.0, "saving_percentage": 0.133630289532294, "model": "FR7K2TY"}\n'  # noqa: E501
+            == '{"name": "iPad Wi-Fi 128GB ricondizionato - Argento (sesta generazione)", "family": "ipad", "store": "it", "url": "https://www.apple.com/it/shop/product/FR7K2TY/A/Refurbished-iPad-Wi-Fi-128GB-Silver-6th-Generation", "price": 389.0, "previous_price": 449.0, "savings_price": 60.0, "saving_percentage": 0.133630289532294, "model": "FR7K2TY"}\n'  # noqa: E501
         )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -14,7 +14,7 @@ class TestParser:
 
         page = io.BytesIO(resource).read().decode("UTF-8")
 
-        products = parse_products("ipad", page)
+        products = parse_products("ipad", "it", page)
         assert len(products) == 34
 
         product = products[0]
@@ -36,7 +36,7 @@ class TestParser:
 
         page = io.BytesIO(resource).read().decode("UTF-8")
 
-        products = parse_products("mac", page)
+        products = parse_products("mac", "it", page)
         assert len(products) == 82
 
         product = products[0]
@@ -55,7 +55,7 @@ class TestParser:
 
         html = io.BytesIO(resource).read().decode()
 
-        products = parse_products("watch", html)
+        products = parse_products("watch", "cn", html)
         assert len(products) == 35
 
         product = products[0]
@@ -74,7 +74,7 @@ class TestParser:
 
         html = io.BytesIO(resource).read().decode()
 
-        products = parse_products("accessory", html)
+        products = parse_products("accessory", "us", html)
         assert len(products) == 2
 
         product = products[0]
@@ -100,7 +100,7 @@ class TestParser:
         #
         # For cases like this, we want to receive an empty list of
         # product instead of an error.
-        products = parse_products("ipad", html)
+        products = parse_products("ipad", "fr", html)
         assert len(products) == 0
 
     def test_product_mac_us(self):
@@ -108,5 +108,5 @@ class TestParser:
 
         html = io.BytesIO(resource).read().decode()
 
-        products = parse_products("mac", html)
+        products = parse_products("mac", "us", html)
         assert len(products) == 138


### PR DESCRIPTION
You need the store id when you export the data using the `json` or `ndjson` output formats, so you know the store the data is coming from.

Here's an example:

```shell
$ rfrb it iphones --format ndjson | head  -n 1 | jq                                               zmoog/add-store-to-product  ✱
{
  "name": "iPhone 12 mini 64GB ricondizionato - Verde (Senza SIM)",
  "family": "iphone",
  "store": "it",
  "url": "https://www.apple.com/it/shop/product/FGE23QL/A/iphone-12-mini-64gb-ricondizionato-verde",
  "price": 609,
  "previous_price": 719,
  "savings_price": 110,
  "saving_percentage": 0.15299026425591097,
  "model": "FGE23QL"
}
```